### PR TITLE
chore: added control over padding params, for export of generators to tensorRT

### DIFF
--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -97,9 +97,9 @@ class CycleGANModel(BaseModel):
         # The naming is different from those used in the paper.
         # Code (vs. paper): G_A (G), G_B (F), D_A (D_Y), D_B (D_X)
         self.netG_A = networks.define_G(opt.input_nc, opt.output_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.G_spectral, opt.init_type, opt.init_gain, self.gpu_ids,opt=self.opt)
+                                        not opt.no_dropout, opt.G_spectral, opt.init_type, opt.init_gain, self.gpu_ids,padding_type=opt.G_padding_type,opt=self.opt)
         self.netG_B = networks.define_G(opt.output_nc, opt.input_nc, opt.ngf, opt.netG, opt.norm,
-                                        not opt.no_dropout, opt.G_spectral, opt.init_type, opt.init_gain, self.gpu_ids,opt=self.opt)
+                                        not opt.no_dropout, opt.G_spectral, opt.init_type, opt.init_gain, self.gpu_ids,padding_type=opt.G_padding_type,opt=self.opt)
 
         if self.isTrain:  # define discriminators
             self.netD_A = networks.define_D(opt.output_nc, opt.ndf, opt.netD,

--- a/models/modules/mobile_modules.py
+++ b/models/modules/mobile_modules.py
@@ -2,12 +2,12 @@ from torch import nn
 
 
 class SeparableConv2d(nn.Module):
-    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0, norm_layer=nn.InstanceNorm2d,
+    def __init__(self, in_channels, out_channels, kernel_size, stride=1, padding=0, padding_mode='zeros', norm_layer=nn.InstanceNorm2d,
                  use_bias=True, scale_factor=1):
         super(SeparableConv2d, self).__init__()
         self.conv = nn.Sequential(
             nn.Conv2d(in_channels=in_channels, out_channels=in_channels * scale_factor, kernel_size=kernel_size,
-                      stride=stride, padding=padding, groups=in_channels, bias=use_bias),
+                      stride=stride, padding=padding, padding_mode=padding_mode, groups=in_channels, bias=use_bias),
             norm_layer(in_channels * scale_factor),
             nn.Conv2d(in_channels=in_channels * scale_factor, out_channels=out_channels,
                       kernel_size=1, stride=1, bias=use_bias),

--- a/models/modules/resnet_architecture/mobile_resnet_generator.py
+++ b/models/modules/resnet_architecture/mobile_resnet_generator.py
@@ -26,7 +26,7 @@ class MobileResnetBlock(nn.Module):
             conv_block += [nn.ReflectionPad2d(1)]
         elif padding_type == 'replicate':
             conv_block += [nn.ReplicationPad2d(1)]
-        elif padding_type == 'zero':
+        elif padding_type == 'zeros':
             p = 1
         else:
             raise NotImplementedError('padding [%s] is not implemented' % padding_type)
@@ -43,7 +43,7 @@ class MobileResnetBlock(nn.Module):
             conv_block += [nn.ReflectionPad2d(1)]
         elif padding_type == 'replicate':
             conv_block += [nn.ReplicationPad2d(1)]
-        elif padding_type == 'zero':
+        elif padding_type == 'zeros':
             p = 1
         else:
             raise NotImplementedError('padding [%s] is not implemented' % padding_type)
@@ -205,15 +205,16 @@ class MobileResnetDecoder(nn.Module):
 
 
 class MobileResnetBlock_attn(nn.Module):
-    def __init__(self, channel, kernel, stride, padding):
+    def __init__(self, channel, kernel, stride, padding_type):
         super(MobileResnetBlock_attn, self).__init__()
         self.channel = channel
         self.kernel = kernel
         self.stride = stride
-        self.padding = padding
-        self.conv1 = SeparableConv2d(channel, channel, kernel, stride, 0)
+        self.padding = 1
+        self.padding_type = padding_type
+        self.conv1 = SeparableConv2d(channel, channel, kernel, stride, padding=self.padding, padding_mode=self.padding_type)
         self.conv1_norm = nn.InstanceNorm2d(channel)
-        self.conv2 = SeparableConv2d(channel, channel, kernel, stride, 0)
+        self.conv2 = SeparableConv2d(channel, channel, kernel, stride, padding=self.padding, padding_mode=self.padding_type)
         self.conv2_norm = nn.InstanceNorm2d(channel)
 
     # weight_init
@@ -222,22 +223,21 @@ class MobileResnetBlock_attn(nn.Module):
             normal_init(self._modules[m], mean, std)
 
     def forward(self, input):
-        x = F.pad(input, (self.padding, self.padding, self.padding, self.padding), 'reflect')
-        x = F.relu(self.conv1_norm(self.conv1(x)))
-        x = F.pad(x, (self.padding, self.padding, self.padding, self.padding), 'reflect')
+        x = F.relu(self.conv1_norm(self.conv1(input)))
         x = self.conv2_norm(self.conv2(x))
 
         return input + x
 
 class MobileResnetGenerator_attn(nn.Module):
     # initializers
-    def __init__(self, input_nc, output_nc, ngf=64, n_blocks=9, use_spectral=False, init_type='normal', init_gain=0.02, gpu_ids=[],size=128,nb_attn = 10,nb_mask_input=1): #nb_attn : nombre de masques d'attention, nb_mask_input : nb de masques d'attention qui vont etre appliqués a l'input
+    def __init__(self, input_nc, output_nc, ngf=64, n_blocks=9, use_spectral=False, init_type='normal', init_gain=0.02, gpu_ids=[],size=128,nb_attn = 10,nb_mask_input=1,padding_type='reflect'): #nb_attn : nombre de masques d'attention, nb_mask_input : nb de masques d'attention qui vont etre appliqués a l'input
         super(MobileResnetGenerator_attn, self).__init__()
         self.input_nc = input_nc
         self.output_nc = output_nc
         self.ngf = ngf
         self.nb = n_blocks
         self.nb_attn = nb_attn
+        self.padding_type = padding_type
         self.nb_mask_input = nb_mask_input
         self.conv1 = spectral_norm(nn.Conv2d(input_nc, ngf, 7, 1, 0),use_spectral)
         self.conv1_norm = nn.InstanceNorm2d(ngf)
@@ -248,7 +248,7 @@ class MobileResnetGenerator_attn(nn.Module):
 
         self.resnet_blocks = []
         for i in range(n_blocks):
-            self.resnet_blocks.append(MobileResnetBlock_attn(ngf * 4, 3, 1, 1))
+            self.resnet_blocks.append(MobileResnetBlock_attn(ngf * 4, 3, 1, self.padding_type))
             self.resnet_blocks[i].weight_init(0, 0.02)
 
         self.resnet_blocks = nn.Sequential(*self.resnet_blocks)
@@ -274,7 +274,10 @@ class MobileResnetGenerator_attn(nn.Module):
 
     # forward method
     def forward(self, input, extract_layer_ids=[], encode_only=False):
-        x = F.pad(input, (3, 3, 3, 3), 'reflect')
+        if self.padding_type == 'reflect':
+            x = F.pad(input, (3, 3, 3, 3), 'reflect')
+        else:
+            x = F.pad(input, (3, 3, 3, 3), 'constant', 0)
         x = F.relu(self.conv1_norm(self.conv1(x)))
         x = F.relu(self.conv2_norm(self.conv2(x)))
         x = F.relu(self.conv3_norm(self.conv3(x)))
@@ -297,7 +300,10 @@ class MobileResnetGenerator_attn(nn.Module):
         
         x_content = F.relu(self.deconv1_norm_content(self.deconv1_content(x)))
         x_content = F.relu(self.deconv2_norm_content(self.deconv2_content(x_content)))
-        x_content = F.pad(x_content, (3, 3, 3, 3), 'reflect')
+        if self.padding_type == 'reflect':
+            x_content = F.pad(x_content, (3, 3, 3, 3), 'reflect')
+        else:
+            x_content = F.pad(x_content, (3, 3, 3, 3), 'constant', 0)
         content = self.deconv3_content(x_content)
         image = self.tanh(content)
 

--- a/models/networks.py
+++ b/models/networks.py
@@ -30,7 +30,7 @@ class Identity(nn.Module):
     def forward(self, x):
         return x
 
-def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, use_spectral=False, init_type='normal', init_gain=0.02, gpu_ids=[], decoder=True, wplus=True, wskip=False, init_weight=True, img_size=128, img_size_dec=128,nb_attn = 10,nb_mask_input=1,opt=None):
+def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, use_spectral=False, init_type='normal', init_gain=0.02, gpu_ids=[], decoder=True, wplus=True, wskip=False, init_weight=True, img_size=128, img_size_dec=128,nb_attn = 10,nb_mask_input=1,padding_type='reflect',opt=None):
     """Create a generator
 
     Parameters:
@@ -62,11 +62,11 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, us
     norm_layer = get_norm_layer(norm_type=norm)
     
     if netG == 'resnet_9blocks':
-        net = ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout, use_spectral=use_spectral, n_blocks=9, init_type=init_type, init_gain=init_gain, gpu_ids=gpu_ids)
+        net = ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout, use_spectral=use_spectral, n_blocks=9, init_type=init_type, init_gain=init_gain, gpu_ids=gpu_ids, padding_type=padding_type)
     elif netG == 'resnet_6blocks':
-        net = ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout, use_spectral=use_spectral, n_blocks=6, decoder=decoder, wplus=wplus, wskip=wskip, init_type=init_type, init_gain=init_gain, gpu_ids=gpu_ids, img_size=img_size,img_size_dec=img_size_dec)
+        net = ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout, use_spectral=use_spectral, n_blocks=6, init_type=init_type, init_gain=init_gain, gpu_ids=gpu_ids, padding_type=padding_type)
     elif netG == 'resnet_12blocks':
-        net = ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout, use_spectral=use_spectral, n_blocks=12, decoder=decoder, wplus=wplus, wskip=wskip, init_type=init_type, init_gain=init_gain, gpu_ids=gpu_ids, img_size=img_size,img_size_dec=img_size_dec)
+        net = ResnetGenerator(input_nc, output_nc, ngf, norm_layer=norm_layer, use_dropout=use_dropout, use_spectral=use_spectral, n_blocks=12, init_type=init_type, init_gain=init_gain, gpu_ids=gpu_ids, padding_type=padding_type)
     elif netG == 'mobile_resnet_9blocks':
         net = MobileResnetGenerator(input_nc, output_nc, ngf=ngf, norm_layer=norm_layer,
                                         dropout_rate=0.0, n_blocks=9, wplus=wplus,
@@ -77,9 +77,9 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, us
     elif netG == 'unet_256':
         net = UnetGenerator(input_nc, output_nc, 8, ngf, norm_layer=norm_layer, use_dropout=use_dropout)
     elif netG == 'resnet_attn':
-        net = ResnetGenerator_attn(input_nc, output_nc, ngf, n_blocks=9, use_spectral=use_spectral,nb_attn = nb_attn,nb_mask_input=nb_mask_input)
+        net = ResnetGenerator_attn(input_nc, output_nc, ngf, n_blocks=9, use_spectral=use_spectral,nb_attn = nb_attn,nb_mask_input=nb_mask_input,padding_type=padding_type)
     elif netG == 'mobile_resnet_attn':
-        net = MobileResnetGenerator_attn(input_nc, output_nc, ngf, n_blocks=9, use_spectral=use_spectral,nb_attn = nb_attn,nb_mask_input=nb_mask_input)
+        net = MobileResnetGenerator_attn(input_nc, output_nc, ngf, n_blocks=9, use_spectral=use_spectral,nb_attn = nb_attn,nb_mask_input=nb_mask_input,padding_type=padding_type)
     elif netG == 'stylegan2':
         net = StyleGAN2Generator(input_nc, output_nc,ngf, use_dropout=use_dropout, opt=opt)
     elif netG == 'smallstylegan2':

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -40,6 +40,7 @@ class BaseOptions():
         parser.add_argument('--D_dropout', action='store_true', help='whether to use dropout in the discriminator')
         parser.add_argument('--D_spectral', action='store_true', help='whether to use spectral norm in the discriminator')
         parser.add_argument('--G_spectral', action='store_true', help='whether to use spectral norm in the generator')
+        parser.add_argument('--G_padding_type', type=str, help='whether to use padding in the generator, zeros or reflect', default='reflect')
         # dataset parameters
         parser.add_argument('--dataset_mode', type=str, default='unaligned', help='chooses how datasets are loaded. [unaligned | aligned | single | colorization]')
         parser.add_argument('--direction', type=str, default='AtoB', help='AtoB or BtoA')

--- a/scripts/export_onnx_model.py
+++ b/scripts/export_onnx_model.py
@@ -12,6 +12,7 @@ parser.add_argument('--model-type',default='mobile_resnet_9blocks',help='model t
 parser.add_argument('--img-size',default=256,type=int,help='square image size')
 parser.add_argument('--cpu',action='store_true',help='whether to export for CPU')
 parser.add_argument('--bw',action='store_true',help='whether input/output is bw')
+parser.add_argument('--padding-type',type=str,help='whether to use padding, zeros or reflect', default='reflect')
 args = parser.parse_args()
 
 if not args.model_out_file:
@@ -31,7 +32,8 @@ img_size = args.img_size
 model = networks.define_G(input_nc,output_nc,ngf,args.model_type,'instance',use_dropout,
                           decoder=decoder,
                           img_size=args.img_size,
-                          img_size_dec=args.img_size)
+                          img_size_dec=args.img_size,
+                          padding_type=args.padding_type)
 if not args.cpu:
     model = model.cuda()
     


### PR DESCRIPTION
This adds padding control, by setting `--G_padding_type` to `zeros`, it allows generator models to be exported to tensorRT. This is because tensorRT does not support non-constant padding nor padding with other values than 0...