### PR TITLE
fix: add clamping in tensor2im function

### DIFF
--- a/util/util.py
+++ b/util/util.py
@@ -71,7 +71,7 @@ def tensor2im(input_image, imtype=np.uint8):
             image_tensor = input_image.data
         else:
             return input_image
-        image_numpy = image_tensor[0].cpu().float().numpy()  # convert it into a numpy array nb : the first image of the batch is displayed
+        image_numpy = image_tensor[0].clamp(-1.0, 1.0).cpu().float().numpy()  # convert it into a numpy array nb : the first image of the batch is displayed
         if image_numpy.shape[0] == 1:  # grayscale to RGB
             image_numpy = np.tile(image_numpy, (3, 1, 1))
         if len(image_numpy.shape)!=2: # it is an image


### PR DESCRIPTION
I add clamping between -1 and 1 in tensor2im function. It fixes the use of sty2 generator because sty2 can produce output outside this range (unlike other generators such as resnet for example) and this is not a desired behavior.