### PR TITLE
fix: netF is initialized on the right gpu

### DIFF
--- a/models/modules/cut_networks.py
+++ b/models/modules/cut_networks.py
@@ -21,8 +21,6 @@ class PatchSampleF(nn.Module):
         for mlp_id, feat in enumerate(feats):
             input_nc = feat.shape[1]
             mlp = nn.Sequential(*[nn.Linear(input_nc, self.nc), nn.ReLU(), nn.Linear(self.nc, self.nc)])
-            if len(self.gpu_ids) > 0:
-                mlp.cuda()
             setattr(self, 'mlp_%d' % mlp_id, mlp)
         init_net(self, self.init_type, self.init_gain, self.gpu_ids)
         for mlp_id in range(len(feats)):


### PR DESCRIPTION
`netF` used to be initialized on first gpu and then transfer to another one. Due to pytorch/pytorch#70048, `netF` had wrong weights on the new gpu.