### PR TITLE
feat(ml): exponential moving average for G

### DIFF
--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -144,7 +144,7 @@ class CUTModel(BaseModel):
                 self.D_global_loss=loss.DiscriminatorGANLoss(opt,self.netD_global,self.device,gan_mode="lsgan")
             self.networks_groups = []
 
-            self.group_G = NetworkGroup(networks_to_optimize=["G","F"],forward_functions=["forward"],backward_functions=["compute_G_loss"],loss_names_list=["loss_names_G"],optimizer=["optimizer_G"],loss_backward=["loss_G"])
+            self.group_G = NetworkGroup(networks_to_optimize=["G","F"],forward_functions=["forward"],backward_functions=["compute_G_loss"],loss_names_list=["loss_names_G"],optimizer=["optimizer_G"],loss_backward=["loss_G"],networks_to_ema=["G"])
             self.networks_groups.append(self.group_G)
 
             D_to_optimize = ["D"]

--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -162,7 +162,7 @@ class CycleGANModel(BaseModel):
                 discriminators += ["netD_A_global","netD_B_global"]
                 self.D_global_loss=loss.DiscriminatorGANLoss(opt,self.netD_A_global,self.device)
 
-            self.group_G = NetworkGroup(networks_to_optimize=["G_A","G_B"],forward_functions=["forward"],backward_functions=["compute_G_loss"],loss_names_list=["loss_names_G"],optimizer=["optimizer_G"],loss_backward=["loss_G"])
+            self.group_G = NetworkGroup(networks_to_optimize=["G_A","G_B"],forward_functions=["forward"],backward_functions=["compute_G_loss"],loss_names_list=["loss_names_G"],optimizer=["optimizer_G"],loss_backward=["loss_G"],networks_to_ema=["G_A","G_B"])
             self.networks_groups.append(self.group_G)
 
             self.group_D = NetworkGroup(networks_to_optimize=["D_A","D_B"],forward_functions=None,backward_functions=["compute_D_loss"],loss_names_list=["loss_names_D"],optimizer=["optimizer_D"],loss_backward=["loss_D"])

--- a/models/re_cut_semantic_mask_model.py
+++ b/models/re_cut_semantic_mask_model.py
@@ -52,7 +52,7 @@ class ReCUTSemanticMaskModel(CUTSemanticMaskModel):
             self.group_P = NetworkGroup(networks_to_optimize=["P_B"],forward_functions=["forward_P"],backward_functions=["compute_P_loss"],loss_names_list=["loss_names_P"],optimizer=["optimizer_P"],loss_backward=["loss_P"])
             self.networks_groups.insert(1,self.group_P)
         else: # P and G networks will be trained in the same time
-            self.group_G = NetworkGroup(networks_to_optimize=["G","P_B"],forward_functions=["forward","forward_P"],backward_functions=["compute_G_loss","compute_P_loss"],loss_names_list=["loss_names_G","loss_names_P"],optimizer=["optimizer_G","optimizer_P"],loss_backward=["loss_G","loss_P"])
+            self.group_G = NetworkGroup(networks_to_optimize=["G","P_B"],forward_functions=["forward","forward_P"],backward_functions=["compute_G_loss","compute_P_loss"],loss_names_list=["loss_names_G","loss_names_P"],optimizer=["optimizer_G","optimizer_P"],loss_backward=["loss_G","loss_P"],networks_to_ema["G"])
             self.networks_groups[0] = self.group_G
 
         self.criterionCycle = torch.nn.L1Loss()

--- a/models/re_cycle_gan_semantic_mask_model.py
+++ b/models/re_cycle_gan_semantic_mask_model.py
@@ -52,7 +52,7 @@ class ReCycleGANSemanticMaskModel(CycleGANSemanticMaskModel):
         if self.opt.no_train_P_fake_images:
             self.group_P = NetworkGroup(networks_to_optimize=["P_A","P_B"],forward_functions=["forward_P"],backward_functions=["compute_P_loss"],loss_names_list=["loss_names_P"],optimizer=["optimizer_P"],loss_backward=["loss_P"])
         else: # P and G networks will be trained in the same time
-            self.group_G = NetworkGroup(networks_to_optimize=["G_A","G_B","P_A","P_B"],forward_functions=["forward","forward_P"],backward_functions=["compute_G_loss","compute_P_loss"],loss_names_list=["loss_names_G","loss_names_P"],optimizer=["optimizer_G","optimizer_P"],loss_backward=["loss_G","loss_P"])
+            self.group_G = NetworkGroup(networks_to_optimize=["G_A","G_B","P_A","P_B"],forward_functions=["forward","forward_P"],backward_functions=["compute_G_loss","compute_P_loss"],loss_names_list=["loss_names_G","loss_names_P"],optimizer=["optimizer_G","optimizer_P"],loss_backward=["loss_G","loss_P"],network_to_ema=["G_A","G_B"])
             self.networks_groups[0] = self.group_G
 
 

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -43,6 +43,8 @@ class BaseOptions():
         parser.add_argument('--G_spectral', action='store_true', help='whether to use spectral norm in the generator')
         parser.add_argument('--G_padding_type', type=str, help='whether to use padding in the generator, zeros or reflect', default='reflect')
         parser.add_argument('--D_projected_interp', type=int, default=-1, help='whether to force projected discriminator interpolation to a value > 224, -1 means no interpolation')
+        parser.add_argument('--G_ema', action='store_true', help='whether to build G via exponential moving average')
+        parser.add_argument('--ema_beta', type=float, default=0.999, help='exponential decay for ema')
         
         # dataset parameters
         parser.add_argument('--dataset_mode', type=str, default='unaligned', help='chooses how datasets are loaded. [unaligned | aligned | single | colorization]')

--- a/train.py
+++ b/train.py
@@ -85,7 +85,7 @@ def train_gpu(rank,world_size,opt,dataset):
             
             model.set_input(data)         # unpack data from dataloader and apply preprocessing
             model.optimize_parameters()   # calculate loss functions, get gradients, update network weights
-
+            
             t_comp = (time.time() - iter_start_time) / opt.batch_size
 
             batch_size=model.get_current_batch_size() * len(opt.gpu_ids)

--- a/util/network_group.py
+++ b/util/network_group.py
@@ -1,8 +1,9 @@
 class NetworkGroup:
-  def __init__(self, networks_to_optimize,forward_functions,backward_functions,loss_names_list,optimizer,loss_backward):
+  def __init__(self, networks_to_optimize,forward_functions,backward_functions,loss_names_list,optimizer,loss_backward,networks_to_ema=[]):
     self.networks_to_optimize = networks_to_optimize
     self.forward_functions = forward_functions
     self.backward_functions = backward_functions
     self.loss_names_list = loss_names_list
     self.optimizer = optimizer
     self.loss_backward = loss_backward
+    self.networks_to_ema = networks_to_ema


### PR DESCRIPTION
This PR adds EMA over G, in the manner of https://arxiv.org/pdf/1710.10196.pdf and http://www.cvlibs.net/publications/Sauer2021NEURIPS_supplementary.pdf

New options:
- `--G_ema` boolean
- `--ema_decay` which defaults 0.999

Notes:
- EMA could apply to D, it seems it is done in https://arxiv.org/pdf/1710.10196.pdf 
- I've seen two 'views' of EMA: one in which G_ema is kept on the side to generate samples, one where G is updated as well. We follow the second one since it prevents from re-generating the fake samples, metrics, etc...
- The reference theoretical paper on EMA for DL is https://openreview.net/pdf?id=SJgw_sRqFQ from ICLR 2019