### PR TITLE
fix : message displayed more accurate when online dataloading fails

### DIFF
--- a/data/online_creation.py
+++ b/data/online_creation.py
@@ -19,6 +19,9 @@ def crop_image(img_path,bbox_path,mask_delta,crop_delta,mask_square,crop_dim,out
             elif line != "" or line != " ":
                 print("%s does not describe a bbox"%line)
 
+        if len(bboxes)==0:
+            print('There is no bbox.')
+
         #Creation of a blank mask
         mask = np.zeros(img.shape[:2],dtype=np.uint8)
 

--- a/data/unaligned_labeled_mask_online_dataset.py
+++ b/data/unaligned_labeled_mask_online_dataset.py
@@ -93,7 +93,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
             A_img,A_label = crop_image(A_img_path,A_label_path,mask_delta=self.opt.online_creation_mask_delta_A,crop_delta=self.opt.online_creation_crop_delta_A,mask_square=self.opt.online_creation_mask_square_A,crop_dim=self.opt.online_creation_crop_size_A,output_dim=self.opt.load_size)
 
         except Exception as e:
-            print('failure with reading A domain image ', A_img_path, ' or label ', A_label_path)
+            print('failure with loading A domain image ', A_img_path, ' or label ', A_label_path)
             print(e)
             return None
        
@@ -115,7 +115,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                     B_label = []
                 
             except Exception as e:
-                print("failed to read B domain image ", B_img_path, 'or label', B_label_path)
+                print("failure with loading B domain image ", B_img_path, 'or label', B_label_path)
                 print(e)
                 return None
 


### PR DESCRIPTION
When an image doesn't have any bbox whereas it should, a message will be displayed in the terminal : "There is no bbox." before the error message "failure with reading A domain image  `path_to_img` or label  `path_to_label`" .