### PR TITLE
fix: APA_img is only added to visual names APA option is true

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -112,6 +112,9 @@ class BaseModel(ABC):
 
         self.objects_to_update = []
 
+        if self.opt.APA:
+            self.visual_names.append(['APA_img'])
+
 
     @staticmethod
     def modify_commandline_options(parser, is_train):

--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -82,13 +82,11 @@ class CUTModel(BaseModel):
 
         if opt.nce_idt and self.isTrain:
             visual_names_B += ['idt_B']
-        self.visual_names = [visual_names_A,visual_names_B]
+        self.visual_names += [visual_names_A,visual_names_B]
 
         if self.opt.diff_aug_policy != '':
             self.visual_names.append(['fake_B_aug'])
             self.visual_names.append(['real_B_aug'])
-
-        self.visual_names.append(['APA_img'])
         
         if self.isTrain:
             self.model_names = ['G', 'F', 'D']

--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -79,7 +79,7 @@ class CycleGANModel(BaseModel):
             visual_names_A.append('idt_B')
             visual_names_B.append('idt_A')
 
-        self.visual_names = [visual_names_A , visual_names_B]  # combine visualizations for A and B
+        self.visual_names += [visual_names_A , visual_names_B]  # combine visualizations for A and B
         # specify the models you want to save to the disk. The training/test scripts will call <BaseModel.save_networks> and <BaseModel.load_networks>.
 
         if self.opt.diff_aug_policy != '':


### PR DESCRIPTION
Quick fix for a bug introduced by https://github.com/jolibrain/joliGAN/pull/111. `APA_img` was added to `visual_names` even when `APA` option was false.