### PR TITLE
feat: segformer can be used for attention masks generation

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -115,6 +115,17 @@ class BaseModel(ABC):
         if self.opt.APA:
             self.visual_names.append(['APA_img'])
 
+        if opt.display_attention_masks:
+            for i in range (opt.nb_mask_attn):
+                temp_visual_names_attn=[]
+                temp_visual_names_attn += ["attention_"+str(i)]
+                temp_visual_names_attn += ["output_"+str(i)]
+                if i < opt.nb_mask_attn - opt.nb_mask_input:
+                    temp_visual_names_attn += ["image_"+str(i)]
+
+                self.visual_names.append(temp_visual_names_attn)
+
+
 
     @staticmethod
     def modify_commandline_options(parser, is_train):
@@ -143,6 +154,24 @@ class BaseModel(ABC):
         """Run forward pass; called by both functions <optimize_parameters> and <test>."""
         self.real_A_pool.query(self.real_A)
         self.real_B_pool.query(self.real_B)
+
+        if hasattr(self,'netG'):
+            netG= self.netG
+        else:
+            netG= self.netG_A
+        
+        if self.opt.display_attention_masks :
+            images,attentions,outputs=netG.get_attention_masks(self.real_A)
+            for i,cur_mask in enumerate(attentions):
+                setattr(self,"attention_"+str(i),cur_mask)
+
+            for i,cur_output in enumerate(outputs):
+                setattr(self,"output_"+str(i),cur_output)
+
+            for i,cur_image in enumerate(images):
+                setattr(self,"image_"+str(i),cur_image)
+
+        
         pass
 
     @abstractmethod

--- a/models/configs/segformer/segformer_config_b0.py
+++ b/models/configs/segformer/segformer_config_b0.py
@@ -1,0 +1,30 @@
+# model settings
+model = dict(
+    type='EncoderDecoder',
+    pretrained=None,
+    backbone=dict(
+        type='MixVisionTransformer',
+        in_channels=3,
+        embed_dims=32,
+        num_stages=4,
+        num_layers=[2, 2, 2, 2],
+        num_heads=[1, 2, 5, 8],
+        patch_sizes=[7, 3, 3, 3],
+        sr_ratios=[8, 4, 2, 1],
+        out_indices=(0, 1, 2, 3),
+        mlp_ratio=4,
+        qkv_bias=True,
+        drop_rate=0.0,
+        attn_drop_rate=0.0,
+        drop_path_rate=0.1),
+    decode_head=dict(
+        type='SegformerHead',
+        in_channels=[32, 64, 160, 256],
+        in_index=[0, 1, 2, 3],
+        channels=256,
+        dropout_ratio=0.1,
+        num_classes=10,
+        align_corners=False),
+    # model training and testing settings
+    train_cfg=dict(),
+    test_cfg=dict(mode='whole'))

--- a/models/configs/segformer/segformer_config_b1.py
+++ b/models/configs/segformer/segformer_config_b1.py
@@ -1,0 +1,7 @@
+_base_ = ['./segformer_config_b0.py']
+
+# model settings
+model = dict(
+    backbone=dict(
+        embed_dims=64, num_heads=[1, 2, 5, 8], num_layers=[2, 2, 2, 2]),
+    decode_head=dict(in_channels=[64, 128, 320, 512]))

--- a/models/configs/segformer/segformer_config_b2.py
+++ b/models/configs/segformer/segformer_config_b2.py
@@ -1,0 +1,7 @@
+_base_ = ['./segformer_config_b0.py']
+
+# model settings
+model = dict(
+    backbone=dict(
+        embed_dims=64, num_heads=[1, 2, 5, 8], num_layers=[3, 4, 6, 3]),
+    decode_head=dict(in_channels=[64, 128, 320, 512]))

--- a/models/configs/segformer/segformer_config_b3.py
+++ b/models/configs/segformer/segformer_config_b3.py
@@ -1,0 +1,7 @@
+_base_ = ['./segformer_config_b0.py']
+
+# model settings
+model = dict(
+    backbone=dict(
+        embed_dims=64, num_heads=[1, 2, 5, 8], num_layers=[3, 4, 18, 3]),
+    decode_head=dict(in_channels=[64, 128, 320, 512]))

--- a/models/configs/segformer/segformer_config_b4.py
+++ b/models/configs/segformer/segformer_config_b4.py
@@ -1,0 +1,7 @@
+_base_ = ['./segformer_config_b0.py']
+
+# model settings
+model = dict(
+    backbone=dict(
+        embed_dims=64, num_heads=[1, 2, 5, 8], num_layers=[3, 8, 27, 3]),
+    decode_head=dict(in_channels=[64, 128, 320, 512]))

--- a/models/configs/segformer/segformer_config_b5.py
+++ b/models/configs/segformer/segformer_config_b5.py
@@ -1,0 +1,7 @@
+_base_ = ['./segformer_config_b0.py']
+
+# model settings
+model = dict(
+    backbone=dict(
+        embed_dims=64, num_heads=[1, 2, 5, 8], num_layers=[3, 6, 40, 3]),
+    decode_head=dict(in_channels=[64, 128, 320, 512]))

--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -68,7 +68,8 @@ class CUTModel(BaseModel):
 
         if opt.nce_idt and self.isTrain:
             visual_names_B += ['idt_B']
-        self.visual_names += [visual_names_A,visual_names_B]
+        self.visual_names.insert(0,visual_names_A)
+        self.visual_names.insert(1,visual_names_B)
 
         if self.opt.diff_aug_policy != '':
             self.visual_names.append(['fake_B_aug'])
@@ -188,6 +189,7 @@ class CUTModel(BaseModel):
     def forward(self):
         """Run forward pass; called by both functions <optimize_parameters> and <test>."""
         super().forward()
+
         self.real = torch.cat((self.real_A, self.real_B), dim=0) if self.opt.nce_idt and self.opt.isTrain else self.real_A
         if self.opt.flip_equivariance:
             self.flipped_for_equivariance = self.opt.isTrain and (np.random.random() < 0.5)

--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -79,7 +79,7 @@ class CycleGANModel(BaseModel):
             visual_names_A.append('idt_B')
             visual_names_B.append('idt_A')
 
-        self.visual_names += [visual_names_A , visual_names_B]  # combine visualizations for A and B
+        self.visual_names = [visual_names_A , visual_names_B] + self.visual_names  # combine visualizations for A and B
         # specify the models you want to save to the disk. The training/test scripts will call <BaseModel.save_networks> and <BaseModel.load_networks>.
 
         if self.opt.diff_aug_policy != '':

--- a/models/cycle_gan_semantic_mask_model.py
+++ b/models/cycle_gan_semantic_mask_model.py
@@ -48,8 +48,6 @@ class CycleGANSemanticMaskModel(CycleGANModel):
             parser.add_argument('--no_train_f_s_A', action='store_true', help='if true f_s wont be trained on domain A')
             parser.add_argument('--fs_light',action='store_true', help='whether to use a light (unet) network for f_s')
             parser.add_argument('--lr_f_s', type=float, default=0.0002, help='f_s learning rate')
-            parser.add_argument('--nb_attn', type=int, default=10, help='number of attention masks')
-            parser.add_argument('--nb_mask_input', type=int, default=1, help='number of attention masks which will be applied on the input image')
             parser.add_argument('--lambda_sem', type=float, default=1.0, help='weight for semantic loss')
             parser.add_argument('--madgrad',action='store_true',help='if true madgrad optim will be used')
 
@@ -61,10 +59,6 @@ class CycleGANSemanticMaskModel(CycleGANModel):
             opt.disc_in_mask = False
         if not hasattr(opt, 'out_mask'):
             opt.out_mask = False
-        if not hasattr(opt, 'nb_attn'):
-            opt.nb_attn = 10
-        if not hasattr(opt, 'nb_mask_input'):
-            opt.nb_mask_input = 1
         if not hasattr(opt, 'fs_light'):
             opt.fs_light = False
             

--- a/models/modules/resnet_architecture/mobile_resnet_generator.py
+++ b/models/modules/resnet_architecture/mobile_resnet_generator.py
@@ -65,9 +65,10 @@ class MobileResnetGenerator(nn.Module):
     def __init__(self, input_nc, output_nc, ngf, norm_layer=nn.InstanceNorm2d,
                  dropout_rate=0.0, n_blocks=9, padding_type='reflect',
                  wplus=True,
-                 img_size=128, img_size_dec=128):
+                 img_size=128, img_size_dec=128,opt=None):
         assert (n_blocks >= 0)
         super(MobileResnetGenerator, self).__init__()
+        self.opt=opt
         if type(norm_layer) == functools.partial:
             use_bias = norm_layer.func == nn.InstanceNorm2d
         else:
@@ -230,15 +231,16 @@ class MobileResnetBlock_attn(nn.Module):
 
 class MobileResnetGenerator_attn(nn.Module):
     # initializers
-    def __init__(self, input_nc, output_nc, ngf=64, n_blocks=9, use_spectral=False,size=128,nb_attn = 10,nb_mask_input=1,padding_type='reflect'): #nb_attn : nombre de masques d'attention, nb_mask_input : nb de masques d'attention qui vont etre appliqués a l'input
+    def __init__(self, input_nc, output_nc, ngf=64, n_blocks=9, use_spectral=False,size=128,padding_type='reflect',opt=None): #nb_mask_attn : nombre de masques d'attention, nb_mask_input : nb de masques d'attention qui vont etre appliqués a l'input
         super(MobileResnetGenerator_attn, self).__init__()
+        self.opt = opt
         self.input_nc = input_nc
         self.output_nc = output_nc
         self.ngf = ngf
         self.nb = n_blocks
-        self.nb_attn = nb_attn
+        self.nb_mask_attn = self.opt.nb_mask_attn
         self.padding_type = padding_type
-        self.nb_mask_input = nb_mask_input
+        self.nb_mask_input = self.opt.nb_mask_input
         self.conv1 = spectral_norm(nn.Conv2d(input_nc, ngf, 7, 1, 0),use_spectral)
         self.conv1_norm = nn.InstanceNorm2d(ngf)
         self.conv2 = spectral_norm(nn.Conv2d(ngf, ngf * 2, 3, 2, 1),use_spectral)
@@ -257,13 +259,13 @@ class MobileResnetGenerator_attn(nn.Module):
         self.deconv1_norm_content = nn.InstanceNorm2d(ngf * 2)
         self.deconv2_content = spectral_norm(nn.ConvTranspose2d(ngf * 2, ngf, 3, 2, 1, 1),use_spectral)
         self.deconv2_norm_content = nn.InstanceNorm2d(ngf)        
-        self.deconv3_content = spectral_norm(nn.Conv2d(ngf, 3 * (self.nb_attn-nb_mask_input), 7, 1, 0),use_spectral)#self.nb_attn-nb_mask_input: nombre d'images générées ou les masques d'attention vont etre appliqués
+        self.deconv3_content = spectral_norm(nn.Conv2d(ngf, 3 * (self.nb_mask_attn-self.nb_mask_input), 7, 1, 0),use_spectral)#self.nb_mask_attn-nb_mask_input: nombre d'images générées ou les masques d'attention vont etre appliqués
 
         self.deconv1_attention = spectral_norm(nn.ConvTranspose2d(ngf * 4, ngf * 2, 3, 2, 1, 1),use_spectral)
         self.deconv1_norm_attention = nn.InstanceNorm2d(ngf * 2)
         self.deconv2_attention = spectral_norm(nn.ConvTranspose2d(ngf * 2, ngf, 3, 2, 1, 1),use_spectral)
         self.deconv2_norm_attention = nn.InstanceNorm2d(ngf)
-        self.deconv3_attention = nn.Conv2d(ngf,self.nb_attn, 1, 1, 0)
+        self.deconv3_attention = nn.Conv2d(ngf,self.nb_mask_attn, 1, 1, 0)
         
         self.tanh = nn.Tanh()
 
@@ -273,7 +275,7 @@ class MobileResnetGenerator_attn(nn.Module):
             normal_init(self._modules[m], mean, std)
 
     # forward method
-    def forward(self, input, extract_layer_ids=[], encode_only=False):
+    def forward(self, input, extract_layer_ids=[], encode_only=False,get_attention_masks=False):
         if self.padding_type == 'reflect':
             x = F.pad(input, (3, 3, 3, 3), 'reflect')
         else:
@@ -309,7 +311,7 @@ class MobileResnetGenerator_attn(nn.Module):
 
         images = []
 
-        for i in range(self.nb_attn - self.nb_mask_input):
+        for i in range(self.nb_mask_attn - self.nb_mask_input):
             images.append(image[:, 3*i:3*(i+1), :, :])
 
         x_attention = F.relu(self.deconv1_norm_attention(self.deconv1_attention(x)))
@@ -321,18 +323,23 @@ class MobileResnetGenerator_attn(nn.Module):
 
         attentions =[]
         
-        for i in range(self.nb_attn):
+        for i in range(self.nb_mask_attn):
             attentions.append(attention[:, i:i+1, :, :].repeat(1, 3, 1, 1))
 
         outputs = []
         
-        for i in range(self.nb_attn-self.nb_mask_input):
+        for i in range(self.nb_mask_attn-self.nb_mask_input):
             outputs.append(images[i]*attentions[i])
-        for i in range(self.nb_attn-self.nb_mask_input,self.nb_attn):
+        for i in range(self.nb_mask_attn-self.nb_mask_input,self.nb_mask_attn):
             outputs.append(input * attentions[i])
+
+        if get_attention_masks:
+            return images,attentions,outputs
         
         o = outputs[0]
-        for i in range(1,self.nb_attn):
+        for i in range(1,self.nb_mask_attn):
             o += outputs[i]
         return o
 
+    def get_attention_masks(self,input):
+        return self.forward(input,get_attention_masks=True)

--- a/models/modules/segformer/segformer_generator.py
+++ b/models/modules/segformer/segformer_generator.py
@@ -1,0 +1,108 @@
+import os
+from mmseg.models import build_segmentor
+from torch import nn
+import mmcv
+
+from models.modules.resnet_architecture.mobile_resnet_generator import MobileResnetDecoder
+
+from .utils import configure_encoder_decoder,configure_new_forward_mit
+
+class Segformer(nn.Module):
+    def __init__(self,opt,num_classes=10,final_conv=False):
+        super().__init__()
+        self.opt = opt
+        cfg = mmcv.Config.fromfile(os.path.join(self.opt.jg_dir,self.opt.config_segformer))
+        cfg.model.pretrained = None
+        cfg.model.train_cfg = None
+        cfg.model.decode_head.num_classes = num_classes
+        self.net = build_segmentor(cfg.model, train_cfg=None, test_cfg=cfg.get('test_cfg'))
+
+        configure_encoder_decoder(self.net)
+        configure_new_forward_mit(self.net.backbone)
+
+        self.use_final_conv = final_conv
+        
+        if self.use_final_conv:
+            self.final_conv = MobileResnetDecoder(num_classes, 3, ngf=64)
+        
+
+    def forward(self, input, extract_layer_ids=[], encode_only=False):
+        out,feats = self.net.encode_decode(input,None, extract_layer_ids=extract_layer_ids,use_resize=not self.use_final_conv)
+
+        if encode_only:
+            return feats
+
+        if self.use_final_conv:
+            out = self.final_conv(out)
+        
+        return out
+
+class SegformerGenerator_attn(nn.Module):
+    # initializers
+    def __init__(self,opt=None,final_conv=False): #nb_attn : total number of attention masks, nb_mask_input :number of attention mask applied to input img directly
+        super(SegformerGenerator_attn, self).__init__()
+        self.opt = opt
+        self.nb_attn = self.opt.nb_mask_attn
+        self.nb_mask_input = self.opt.nb_mask_input
+        self.use_final_conv = final_conv
+        self.tanh = nn.Tanh()
+
+        cfg = mmcv.Config.fromfile(os.path.join(self.opt.jg_dir,self.opt.config_segformer))
+        cfg.model.pretrained = None
+        cfg.model.train_cfg = None
+        cfg.model.auxiliary_head = cfg.model.decode_head.copy()
+        if self.use_final_conv:
+            num_cls = 256
+        else:
+            num_cls = 3*(self.nb_attn-self.nb_mask_input)
+        cfg.model.decode_head.num_classes = num_cls
+        cfg.model.auxiliary_head.num_classes = self.nb_attn
+        self.segformer = build_segmentor(cfg.model, train_cfg=None, test_cfg=cfg.get('test_cfg'))
+        self.segformer.train()
+        self.softmax_ = nn.Softmax(dim=1)
+
+        configure_encoder_decoder(self.segformer)
+        configure_new_forward_mit(self.segformer.backbone)
+
+        self.use_final_conv = final_conv
+        
+        if self.use_final_conv:
+            self.final_conv = MobileResnetDecoder(num_cls,3*(self.nb_attn-self.nb_mask_input) , ngf=64)
+
+
+    # forward method
+    def forward(self, input, extract_layer_ids=[], encode_only=False,get_attention_masks=False):
+        image,attention,feats = self.segformer.encode_decode(input,None, extract_layer_ids=extract_layer_ids,use_resize=not self.use_final_conv)
+        if encode_only:
+            return feats
+        images = []
+
+        if self.use_final_conv:
+            image = self.final_conv(image)
+
+        for i in range(self.nb_attn - self.nb_mask_input):
+            images.append(image[:, 3*i:3*(i+1), :, :])
+            
+        attention = self.softmax_(attention)
+        attentions =[]
+        
+        for i in range(self.nb_attn):
+            attentions.append(attention[:, i:i+1, :, :].repeat(1, 3, 1, 1))
+
+        outputs = []
+        
+        for i in range(self.nb_attn-self.nb_mask_input):
+            outputs.append(images[i]*attentions[i])
+        for i in range(self.nb_attn-self.nb_mask_input,self.nb_attn):
+            outputs.append(input * attentions[i])
+
+        if get_attention_masks:
+            return images,attentions,outputs
+            
+        o = outputs[0]
+        for i in range(1,self.nb_attn):
+            o += outputs[i]
+        return o
+
+    def get_attention_masks(self,input):
+        return self.forward(input,get_attention_masks=True)

--- a/models/modules/segformer/utils.py
+++ b/models/modules/segformer/utils.py
@@ -1,0 +1,86 @@
+from mmseg.models.utils import nlc_to_nchw
+from mmseg.ops import resize
+
+def configure_new_forward_mit(obj):
+    def new_forward_mit(x, extract_layer_ids=[]):
+        outs = []
+        feats = []
+
+        for i, layer in enumerate(obj.layers):
+            x, hw_shape = layer[0](x)
+            for block in layer[1]:
+                x = block(x, hw_shape)
+            x = layer[2](x)
+            x = nlc_to_nchw(x, hw_shape)
+            if i in obj.out_indices:
+                outs.append(x)
+            if i in extract_layer_ids:
+                feats.append(x)
+
+        if len(feats)>0:
+            return outs,feats
+        else:
+            return outs
+
+    obj.forward = new_forward_mit
+
+
+def configure_new_extract_feat_encoder_encoder(obj):
+    def new_extract_feat_encoder_encoder(img,extract_layer_ids=[]):
+        """Extract features from images."""
+        x = obj.backbone(img,extract_layer_ids)
+        if len(extract_layer_ids)>0:
+            x,feats = x
+            return x,feats
+        if obj.with_neck:
+            x = obj.neck(x)
+        return x
+    obj.extract_feat = new_extract_feat_encoder_encoder
+
+def configure_new_encode_decode_encoder_encoder(obj):
+    def new_encode_decode_encoder_encoder(img, img_metas, extract_layer_ids=[],use_resize=True):
+        """Encode images with backbone and decode into a semantic segmentation
+        map of the same size as input."""
+        x = obj.extract_feat(img,extract_layer_ids=extract_layer_ids)
+        if len(extract_layer_ids)>0:
+            x,feats = x
+        out = obj._decode_head_forward_test(x, img_metas)
+        if use_resize:
+            out = resize(
+                input=out,
+                size=img.shape[2:],
+                mode='bilinear',
+                align_corners=obj.align_corners)
+
+        if hasattr(obj,'auxiliary_head'):
+            out2 = obj._auxiliary_head_forward_test(x, img_metas)
+            out2 = resize(
+                input=out2,
+                size=img.shape[2:],
+                mode='bilinear',
+                align_corners=obj.align_corners)
+            if len(extract_layer_ids)>0:
+                return out, out2,feats
+            else:
+                return out, out2, None
+
+        if len(extract_layer_ids)>0:
+            return out,feats
+        else:
+            return out, None
+
+    obj.encode_decode = new_encode_decode_encoder_encoder
+
+
+def configure_new_auxiliary_head_forward_test_encoder_decoder(obj):
+    def new_auxiliary_head_forward_test(x, img_metas):
+        """Run forward function and calculate loss for auxiliary head in
+        training."""
+        seg_logits = obj.auxiliary_head.forward_test(x, img_metas, obj.test_cfg)
+        return seg_logits
+    obj._auxiliary_head_forward_test = new_auxiliary_head_forward_test
+
+def configure_encoder_decoder(obj):
+    configure_new_extract_feat_encoder_encoder(obj)
+    configure_new_encode_decode_encoder_encoder(obj)
+    configure_new_auxiliary_head_forward_test_encoder_decoder(obj)

--- a/models/networks.py
+++ b/models/networks.py
@@ -19,6 +19,7 @@ from .modules.fid.pytorch_fid.inception import InceptionV3
 from .modules.stylegan_networks import StyleGAN2Discriminator, StyleGAN2Generator, TileStyleGAN2Discriminator
 from .modules.cut_networks import PatchSampleF
 from .modules.projected_d.discriminator import ProjectedDiscriminator
+from .modules.segformer.segformer_generator import Segformer,SegformerGenerator_attn
 
 class BaseNetwork(nn.Module):
     def __init__(self):
@@ -32,7 +33,7 @@ class Identity(nn.Module):
     def forward(self, x):
         return x
 
-def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, use_spectral=False, init_type='normal', init_gain=0.02, gpu_ids=[], decoder=True, wplus=True, wskip=False, init_weight=True, img_size=128, img_size_dec=128,nb_attn = 10,nb_mask_input=1,padding_type='reflect',opt=None):
+def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, use_spectral=False, init_type='normal', init_gain=0.02, gpu_ids=[], decoder=True, wplus=True, wskip=False, init_weight=True, img_size=128, img_size_dec=128,padding_type='reflect',opt=None):
     """Create a generator
 
     Parameters:
@@ -84,13 +85,20 @@ def define_G(input_nc, output_nc, ngf, netG, norm='batch', use_dropout=False, us
     elif netG == 'unet_256':
         net = UnetGenerator(input_nc, output_nc, 8, ngf, norm_layer=norm_layer, use_dropout=use_dropout)
     elif netG == 'resnet_attn':
-        net = ResnetGenerator_attn(input_nc, output_nc, ngf, n_blocks=9, use_spectral=use_spectral,nb_attn = nb_attn,nb_mask_input=nb_mask_input,padding_type=padding_type)
+        net = ResnetGenerator_attn(input_nc, output_nc, ngf, n_blocks=9, use_spectral=use_spectral,padding_type=padding_type,opt=opt)
     elif netG == 'mobile_resnet_attn':
-        net = MobileResnetGenerator_attn(input_nc, output_nc, ngf, n_blocks=9, use_spectral=use_spectral,nb_attn = nb_attn,nb_mask_input=nb_mask_input,padding_type=padding_type)
+        net = MobileResnetGenerator_attn(input_nc, output_nc, ngf, n_blocks=9, use_spectral=use_spectral,padding_type=padding_type,opt=opt)
     elif netG == 'stylegan2':
         net = StyleGAN2Generator(input_nc, output_nc,ngf, use_dropout=use_dropout, opt=opt)
     elif netG == 'smallstylegan2':
         net = StyleGAN2Generator(input_nc, output_nc,ngf, use_dropout=use_dropout, n_blocks=2, opt=opt)
+        return net
+    elif netG == 'segformer_attn_conv':
+        net = SegformerGenerator_attn(opt=opt,final_conv=True)
+        return net
+    elif netG == 'segformer_conv':
+        net = Segformer(opt=opt,num_classes=256,final_conv=True)
+        return net
 
     else:
         raise NotImplementedError('Generator model name [%s] is not recognized' % netG)

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -62,5 +62,12 @@ class TrainOptions(BaseOptions):
 
         parser.add_argument('--display_diff_fake_real', action='store_true',help='if True x - G(x) is displayed')
 
+        #Segformer Options
+        parser.add_argument('--config_segformer',type=str,default='models/configs/segformer/segformer_config_b0.py',help='path to segforme configuration file')
+
+        parser.add_argument('--display_attention_masks',action='store_true')
+        parser.add_argument('--nb_mask_attn',default=10)
+        parser.add_argument('--nb_mask_input',default=1)
+
         self.isTrain = True
         return parser

--- a/train.py
+++ b/train.py
@@ -146,6 +146,7 @@ def train_gpu(rank,world_size,opt,dataset):
 if __name__ == '__main__':
     signal.signal(signal.SIGINT, signal_handler) #to really kill the process
     opt = TrainOptions().parse()   # get training options
+    opt.jg_dir = os.path.join("/".join(__file__.split("/")[:-1]))
     world_size=len(opt.gpu_ids)
 
     dataset=create_dataset(opt)


### PR DESCRIPTION
We can now use segformer (from https://github.com/open-mmlab/mmsegmentation) to compute attention masks.

New librairies needed :
- `mmcv-full`

New options : 
- `config_segformer path_to_segformer_config_file` : path_to_segformer_config_file needs to point a segformer configuration file (basic config file is `./configs/segformer/segformer_config_b3.py `)

Example of commandline : 
```
python3 train.py --dataroot path_to_dataset--checkpoints_dir path_to_checkpoint_dir--name test_segformer --model cut --netG segformer_attn --display_env test_segformer --dataset_mode unaligned --config_segformer ./configs/segformer/segformer_config_b3.py
```