### PR TITLE
feat: pretrained segformer backbone (mit) as feature extractor for projected D

### DIFF
--- a/models/modules/projected_d/discriminator.py
+++ b/models/modules/projected_d/discriminator.py
@@ -5,8 +5,8 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .blocks import DownBlock, DownBlockPatch, conv2d
-from .projector import F_RandomProj
 #from pg_modules.diffaug import DiffAugment
+from .projector import Proj
 
 
 class SingleDisc(nn.Module):
@@ -150,14 +150,19 @@ class MultiScaleD(nn.Module):
 class ProjectedDiscriminator(torch.nn.Module):
     def __init__(
         self,
+        projector_model,
         interp=-1,
         backbone_kwargs={'cout': 64, 'expand': True},
+        config_path='',
+        weight_path='',
         **kwargs
     ):
         super().__init__()
         self.interp = interp
-        self.freeze_feature_network = F_RandomProj(**backbone_kwargs)
+
+        self.freeze_feature_network = Proj(projector_model,config_path = config_path,weight_path = weight_path,**backbone_kwargs)            
         self.freeze_feature_network.requires_grad_(False)
+        
         self.discriminator = MultiScaleD(
             channels=self.freeze_feature_network.CHANNELS,
             resolutions=self.freeze_feature_network.RESOLUTIONS,

--- a/models/networks.py
+++ b/models/networks.py
@@ -1,3 +1,4 @@
+import os
 import torch.nn as nn
 import functools
 from torch.optim import lr_scheduler
@@ -149,8 +150,9 @@ def define_D(input_nc, ndf, netD, n_layers_D=3, norm='batch', use_dropout=False,
         template=netD
         net = torch_model(input_nc, ndf, nclasses,opt.data_crop_size, template, pretrained=False)
     elif netD == 'projected_d': # D in projected feature space
-        net = ProjectedDiscriminator(interp=224 if opt.data_crop_size < 224 else opt.D_projected_interp)
+        net = ProjectedDiscriminator(opt.D_proj_network_type,interp=224 if opt.data_crop_size < 224 else opt.D_proj_interp,config_path=os.path.join(opt.jg_dir,opt.D_proj_config_segformer),weight_path=os.path.join(opt.jg_dir,opt.D_proj_weight_segformer))
         return net # no init since custom frozen backbone
+
     else:
         raise NotImplementedError('Discriminator model name [%s] is not recognized' % netD)
     return init_net(net, init_type, init_gain, gpu_ids,init_weight= 'stylegan2' not in netD)

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -63,9 +63,13 @@ class BaseOptions():
         parser.add_argument('--D_norm', type=str, default='instance', choices=['instance', 'batch', 'none'], help='instance normalization or batch normalization for D')
         parser.add_argument('--D_dropout', action='store_true', help='whether to use dropout in the discriminator')
         parser.add_argument('--D_spectral', action='store_true', help='whether to use spectral norm in the discriminator')
-        parser.add_argument('--D_projected_interp', type=int, default=-1, help='whether to force projected discriminator interpolation to a value > 224, -1 means no interpolation')
+        parser.add_argument('--D_proj_interp', type=int, default=-1, help='whether to force projected discriminator interpolation to a value > 224, -1 means no interpolation')
+        parser.add_argument('--D_proj_network_type', type=str, default='efficientnet',choices=['efficientnet','segformer'])
         parser.add_argument('--D_no_antialias', action='store_true', help='if specified, use stride=2 convs instead of antialiased-downsampling (sad)')
         parser.add_argument('--D_no_antialias_up', action='store_true', help='if specified, use [upconv(learned filter)] instead of [upconv(hard-coded [1,3,3,1] filter), conv]')
+        parser.add_argument('--D_proj_config_segformer',type=str,default='models/configs/segformer/segformer_config_b0.py',help='path to segformer configuration file')
+        parser.add_argument('--D_proj_weight_segformer',type=str,default='models/configs/segformer/pretrain/segformer_mit-b0.pth',help='path to segformer weight')
+
         
         # semantic network
         parser.add_argument('--f_s_light',action='store_true', help='whether to use a light (unet) network for f_s')
@@ -74,6 +78,7 @@ class BaseOptions():
         parser.add_argument('--f_s_semantic_threshold',default=1.0,type=float,help='threshold of the semantic classifier loss below with semantic loss is applied')
         parser.add_argument('--f_s_all_classes_as_one',action='store_true',help='if true, all classes will be considered as the same one (ie foreground vs background)')
         parser.add_argument('--f_s_nf', type=int, default=64, help='# of filters in the first conv layer of classifier')
+        
 
         # dataset parameters
         parser.add_argument('--data_dataset_mode', type=str, default='unaligned', help='chooses how datasets are loaded. [unaligned | aligned | single | colorization]')


### PR DESCRIPTION
We can now choose between a pretrained efficient net or a pretrained Mixvisiontransformer as feature extractor for projected D.

New options :

- `--D_proj_network_type` to choose between efficientnet and transformer feature_extractor
- `--D_proj_config_segformer`path to segformer config file
- `--D_proj_weight_segformer` path to segformer weights
Usage : 
```
python3 train.py --D_proj_config_segformer path/to/segformer_config.py --D_proj_weight_segformer path/to/segformer_weight.pth --D_netD projected_d `--D_proj_network_type` transformer
```