### PR TITLE
fix: mask display when more than one class

### DIFF
--- a/util/util.py
+++ b/util/util.py
@@ -71,10 +71,11 @@ def tensor2im(input_image, imtype=np.uint8):
             image_tensor = input_image.data
         else:
             return input_image
-        image_numpy = image_tensor[0].clamp(-1.0, 1.0).cpu().float().numpy()  # convert it into a numpy array nb : the first image of the batch is displayed
+        image_numpy = image_tensor[0].cpu().float().numpy()  # convert it into a numpy array nb : the first image of the batch is displayed
         if image_numpy.shape[0] == 1:  # grayscale to RGB
             image_numpy = np.tile(image_numpy, (3, 1, 1))
         if len(image_numpy.shape)!=2: # it is an image
+            image_numpy.clip(-1,1)
             image_numpy = (np.transpose(image_numpy, (1, 2, 0)) + 1) / 2.0 * 255.0  # post-processing: transpose and scaling
         else : # it is  a mask
             image_numpy = image_numpy.astype(np.uint8)


### PR DESCRIPTION
Images were clamped between -1 and 1, so it wasn't possible to display masks with more than one class.