### PR TITLE
feat: use label 0 in domain B for object removal

### DIFF
--- a/models/cut_semantic_mask_model.py
+++ b/models/cut_semantic_mask_model.py
@@ -175,8 +175,11 @@ class CUTSemanticMaskModel(CUTModel):
     def compute_G_loss(self):
         """Calculate GAN and NCE loss for the generator"""
         super().compute_G_loss()
-        
-        self.loss_sem = self.opt.train_sem_lambda * self.criterionf_s(self.pfB, self.input_A_label)
+        if self.opt.train_mask_for_removal:
+            label_fake_B = torch.zeros_like(self.input_A_label)
+        else:
+            label_fake_B = self.input_A_label
+        self.loss_sem = self.opt.train_sem_lambda * self.criterionf_s(self.pfB, label_fake_B)
         if not hasattr(self, 'loss_f_s') or self.loss_f_s > self.opt.f_s_semantic_threshold:
             self.loss_sem = 0 * self.loss_sem
         self.loss_G += self.loss_sem

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -78,6 +78,7 @@ class TrainOptions(BaseOptions):
         parser.add_argument('--train_mask_loss_out_mask', type=str, default='L1', help='loss for mask, L1, MSE or Charbonnier')
         parser.add_argument('--train_mask_charbonnier_eps', type=float, default=1e-6, help='Charbonnier loss epsilon value')
         parser.add_argument('--train_mask_disjoint_f_s',action='store_true', help='whether to use a disjoint f_s with the same exact structure')
+        parser.add_argument('--train_mask_for_removal',action='store_true',help='if true, object removal mode, domain B images with label 0, cut models only')
 
         # train with re-(cycle/cut)
         parser.add_argument('--alg_re_adversarial_loss_p',action='store_true',help='if True, also train the prediction model with an adversarial loss')


### PR DESCRIPTION
With removing object task, we train `f_s` to detect an object on domain A images. So, it should predict only zeros (ie no object detected) on fake B images.

Usage :
```
python3 train.py --train_mask_for_removal
```