### PR TITLE
fix: new options names for unaligned_labeled_mask

### DIFF
--- a/data/unaligned_labeled_mask_dataset.py
+++ b/data/unaligned_labeled_mask_dataset.py
@@ -30,21 +30,21 @@ class UnalignedLabeledMaskDataset(BaseDataset):
         """
         BaseDataset.__init__(self, opt)
 
-        btoA = self.opt.direction == 'BtoA'
-        self.input_nc = self.opt.output_nc if btoA else self.opt.input_nc       # get the number of channels of input image
-        output_nc = self.opt.input_nc if btoA else self.opt.output_nc      # get the number of channels of output image
+        btoA = self.opt.data_direction == 'BtoA'
+        self.input_nc = self.opt.model_output_nc if btoA else self.opt.model_input_nc       # get the number of channels of input image
+        output_nc = self.opt.model_input_nc if btoA else self.opt.model_output_nc      # get the number of channels of output image
 
         
         self.dir_A = os.path.join(opt.dataroot, opt.phase + 'A')  # create a path '/path/to/data/trainA'
         self.dir_B = os.path.join(opt.dataroot, opt.phase + 'B')  # create a path '/path/to/data/trainB'
         if os.path.exists(self.dir_A):
-            self.A_img_paths, self.A_label_paths = make_labeled_path_dataset(self.dir_A,'/paths.txt', opt.max_dataset_size)   # load images from '/path/to/data/trainA/paths.txt' as well as labels
+            self.A_img_paths, self.A_label_paths = make_labeled_path_dataset(self.dir_A,'/paths.txt', opt.data_max_dataset_size)   # load images from '/path/to/data/trainA/paths.txt' as well as labels
         else:
-            self.A_img_paths, self.A_label_paths = make_labeled_path_dataset(opt.dataroot,'/paths.txt', opt.max_dataset_size)   # load images from '/path/to/data/trainA/paths.txt' as well as labels
+            self.A_img_paths, self.A_label_paths = make_labeled_path_dataset(opt.dataroot,'/paths.txt', opt.data_max_dataset_size)   # load images from '/path/to/data/trainA/paths.txt' as well as labels
         self.A_size = len(self.A_img_paths)  # get the size of dataset A
 
         if os.path.exists(self.dir_B):
-            self.B_img_paths, self.B_label_paths = make_labeled_path_dataset(self.dir_B,'/paths.txt', opt.max_dataset_size)    # load images from '/path/to/data/trainB'
+            self.B_img_paths, self.B_label_paths = make_labeled_path_dataset(self.dir_B,'/paths.txt', opt.data_max_dataset_size)    # load images from '/path/to/data/trainB'
             self.B_size = len(self.B_img_paths)  # get the size of dataset B
 
         self.transform=get_transform_seg(self.opt, grayscale=(self.input_nc == 1))
@@ -60,7 +60,7 @@ class UnalignedLabeledMaskDataset(BaseDataset):
             return None
        
         A,A_label = self.transform(A_img,A_label)
-        if self.opt.all_classes_as_one:
+        if self.opt.f_s_all_classes_as_one:
             A_label = (A_label >= 1)*1
 
         if B_img_path is not None:
@@ -79,7 +79,7 @@ class UnalignedLabeledMaskDataset(BaseDataset):
             if B_label_path is not None: # B label is optional
                 B_label = Image.open(B_label_path)
                 B,B_label = self.transform(B_img,B_label)
-                if self.opt.all_classes_as_one:
+                if self.opt.f_s_all_classes_as_one:
                     B_label = (B_label >= 1)*1
 
             else:


### PR DESCRIPTION
Options names weren't updated in a former PR for unaligned labeled mask dataloader