### PR TITLE
fix: cyclegan semantic mask failure with f_s

### DIFF
--- a/tests/test_run_semantic_mask.py
+++ b/tests/test_run_semantic_mask.py
@@ -33,7 +33,7 @@ json_like_dict={
 }
 
 models_semantic_mask=[
-#    "cycle_gan_semantic_mask",
+    "cycle_gan_semantic_mask",
     "cut_semantic_mask",
 ]
 


### PR DESCRIPTION
Unit tests in `tests/test_run_semantic_mask.py` fail with cyclegan, something related to f_s:

```
create web directory /data1/beniz/checkpoints/tests/joligan_utest_cycle_gan_semantic_mask/web...
../aten/src/ATen/native/cuda/NLLLoss2d.cu:93: nll_loss2d_forward_kernel: block: [0,0,0], thread: [960,0,0] Assertion `t >= 0 && t < n_classes` faile
d.
```
The exact same mini dataset works fine with CUT.

I've initiated this PR with small fixes to cyclegan with semantic masks that I did find when looking for a fix to the issue.