### PR TITLE
fix: wrong option name in test and add comment in json option loading

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -384,7 +384,7 @@ class BaseOptions():
 
         if len(flat_json) != 0:
             #raise ValueError("%d remaining keys in json args: %s" % (len(json_args), ",".join(json_args.keys())))
-            print("%d remaining keys in json args: %s" % (len(flat_json), ",".join(flat_json.keys())))
+            print("%d remaining keys in json args: %s" % (len(flat_json), ",".join(flat_json.keys()))) # it's not an error anymore because server launching is done with all of the options even those from other models, raising an error will lead to a server crash 
 
         return self._after_parse(opt)
 

--- a/tests/test_run_semantic_mask.py
+++ b/tests/test_run_semantic_mask.py
@@ -20,7 +20,7 @@ json_like_dict={
     'data_max_dataset_size': 10,
     'train_mask_out_mask': True,
     'f_s_net': 'unet',
-    'f_s_semantic_classes': 2,
+    'f_s_semantic_nclasses': 2,
     'dataaug_D_noise': 0.001,
     'train_sem_use_label_B': True,
     'data_relative_paths': True,


### PR DESCRIPTION
Fix a typo in `f_s_semantic_nclasses` and add a comment to remember why we do not raise an error when there is a wrong option name in  a json option file.