### PR TITLE
fix: install all requirements for github actions

### DIFF
--- a/.github/workflows/github-actions-doc-options-update.yml
+++ b/.github/workflows/github-actions-doc-options-update.yml
@@ -1,4 +1,4 @@
-name: GitHub Actions Demo
+name: Doc auto generation
 on: 
   push:
     branches: [master]

--- a/.github/workflows/requirements_github_actions.txt
+++ b/.github/workflows/requirements_github_actions.txt
@@ -7,3 +7,4 @@ timm==0.5.4
 visdom==0.1.8.9
 torchviz
 imgaug
+pydantic


### PR DESCRIPTION
Install all requirements to prevent github action doc generation from failing.