### PR TITLE
fix: joliGAN docker build with commit version log

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -8,7 +8,8 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     python3-pytest \
     sudo \
     wget \
-    unzip
+    unzip \
+    git
 
 RUN mkdir /app
 

--- a/server/joligan_api.py
+++ b/server/joligan_api.py
@@ -13,13 +13,12 @@ from data import create_dataset
 from enum import Enum
 from pydantic import create_model, BaseModel, Field
 
-
 git_hash = (
     subprocess.check_output(["git", "rev-parse", "HEAD"], cwd=os.path.dirname(__file__))
     .decode("ascii")
     .strip()
 )
-print("Launching JoliGAN Server\ncommit=%s" % git_hash)
+print("Launching JoliGAN Server\ncommit=%s" % git_hash, flush=True)
 
 description = """This is the JoliGAN server API documentation.
 """


### PR DESCRIPTION
Add `git` to `Dockerfile.build` in order to print latest joliGAN server commit hash.