### PR TITLE
feat: option to go through resnet blocks two times (backward compatibility)

### DIFF
--- a/models/modules/resnet_architecture/resnet_generator.py
+++ b/models/modules/resnet_architecture/resnet_generator.py
@@ -399,6 +399,7 @@ class ResnetGenerator_attn(BaseGenerator_attn):
         size=128,
         padding_type="reflect",
         mobile=False,
+        twice_resnet_blocks=False,
     ):
         super(ResnetGenerator_attn, self).__init__(
             nb_mask_attn=nb_mask_attn, nb_mask_input=nb_mask_input
@@ -413,6 +414,8 @@ class ResnetGenerator_attn(BaseGenerator_attn):
         self.ngf = ngf
         self.nb = n_blocks
         self.padding_type = padding_type
+        self.twice_resnet_blocks = twice_resnet_blocks
+
         self.conv1 = spectral_norm(nn.Conv2d(input_nc, ngf, 7, 1, 0), use_spectral)
         self.conv1_norm = nn.InstanceNorm2d(ngf)
         self.conv2 = spectral_norm(nn.Conv2d(ngf, ngf * 2, 3, 2, 1), use_spectral)
@@ -484,7 +487,10 @@ class ResnetGenerator_attn(BaseGenerator_attn):
         return feat, feats
 
     def compute_attention_content(self, feat):
-        x = feat
+        if self.twice_resnet_blocks:
+            x = self.resnet_blocks(feat)
+        else:
+            x = feat
 
         x_content = F.relu(self.deconv1_norm_content(self.deconv1_content(x)))
         x_content = F.relu(self.deconv2_norm_content(self.deconv2_content(x_content)))

--- a/models/networks.py
+++ b/models/networks.py
@@ -72,6 +72,7 @@ def define_G(
     jg_dir,
     G_config_segformer,
     G_stylegan2_num_downsampling,
+    G_backward_compatibility_twice_resnet_blocks,
     **unused_options
 ):
     """Create a generator
@@ -192,6 +193,7 @@ def define_G(
             n_blocks=9,
             use_spectral=G_spectral,
             padding_type=G_padding_type,
+            twice_resnet_blocks=G_backward_compatibility_twice_resnet_blocks,
         )
     elif G_netG == "mobile_resnet_attn":
         net = ResnetGenerator_attn(
@@ -204,6 +206,7 @@ def define_G(
             use_spectral=G_spectral,
             padding_type=G_padding_type,
             mobile=True,
+            twice_resnet_blocks=G_backward_compatibility_twice_resnet_blocks,
         )
     elif G_netG == "stylegan2":
         net = StyleGAN2Generator(

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -206,7 +206,14 @@ class BaseOptions:
             help="path to segforme configuration file for G",
         )
         parser.add_argument("--G_attn_nb_mask_attn", default=10, type=int)
+
         parser.add_argument("--G_attn_nb_mask_input", default=1, type=int)
+
+        parser.add_argument(
+            "--G_backward_compatibility_twice_resnet_blocks",
+            action="store_true",
+            help="if true, feats will go througt resnet blocks two times for resnet_attn generators. This option will be deleted, it's for backward compatibility (old models were trained that way).",
+        )
 
         # discriminator
         parser.add_argument(


### PR DESCRIPTION
We use to have a bug which made feats going through resnet blocks two times in resnet_attn. We fixed but some models were trained that way, so we need an option to allow us to stille use those models.

New option :
`--G_backward_compatibility_two_times_resnet_blocks` : if true, feats will go through resnet blocks two times in resnet_attn