### PR TITLE
chore: error warning data load

### DIFF
--- a/data/base_dataset.py
+++ b/data/base_dataset.py
@@ -15,6 +15,7 @@ from torchvision.transforms import InterpolationMode
 import imgaug as ia
 import imgaug.augmenters as iaa
 import os
+import warnings
 
 
 class BaseDataset(data.Dataset, ABC):
@@ -36,6 +37,7 @@ class BaseDataset(data.Dataset, ABC):
         self.opt = opt
         self.root = opt.dataroot
         self.sv_dir = os.path.join(opt.checkpoints_dir, opt.name)
+        self.warning_mode = self.opt.warning_mode
 
     @staticmethod
     def modify_commandline_options(parser, is_train):
@@ -68,6 +70,9 @@ class BaseDataset(data.Dataset, ABC):
             B_paths (str)    -- image paths
             A_label (tensor) -- mask label of image A
         """
+        if not self.warning_mode:
+            warnings.simplefilter("ignore")
+
         A_img_path = self.A_img_paths[
             index % self.A_size
         ]  # make sure index is within then range

--- a/data/temporal_dataset.py
+++ b/data/temporal_dataset.py
@@ -128,13 +128,7 @@ class TemporalDataset(BaseDataset):
                 )
 
             except Exception as e:
-                print(
-                    "failure with loading A domain image ",
-                    cur_A_img_path,
-                    " or label ",
-                    cur_A_label_path,
-                )
-                print(e)
+                print(e, f"{i+1}th frame of domain A in temporal dataloading")
                 return None
 
             images_A.append(cur_A_img)
@@ -198,13 +192,7 @@ class TemporalDataset(BaseDataset):
                 )
 
             except Exception as e:
-                print(
-                    "failure with loading B domain image ",
-                    cur_B_img_path,
-                    " or label ",
-                    cur_B_label_path,
-                )
-                print(e)
+                print(e, f"{i+1}th frame of domain B in temporal dataloading")
                 return None
 
             images_B.append(cur_B_img)

--- a/data/unaligned_labeled_mask_dataset.py
+++ b/data/unaligned_labeled_mask_dataset.py
@@ -98,26 +98,31 @@ class UnalignedLabeledMaskDataset(BaseDataset):
         if B_img_path is not None:
             try:
                 B_img = Image.open(B_img_path).convert("RGB")
-                if B_label_path is not None:
-                    B_label = Image.open(B_label_path)
-                    B, B_label = self.transform(B_img, B_label)
-                    if torch.any(B_label > self.semantic_nclasses - 1):
-                        warnings.warn(
-                            "B label is above number of semantic classes for img %s and label %s"
-                            % (B_img_path, B_label_path)
-                        )
-                        B_label = torch.clamp(B_label, max=self.semantic_nclasses - 1)
-                else:
-                    B = self.transform_noseg(B_img)
-                    B_label = []
             except:
                 print(
                     "failed to read B domain image ",
                     B_img_path,
-                    " or label",
-                    B_label_path,
                 )
                 return None
+
+            if B_label_path is not None:
+                try:
+                    B_label = Image.open(B_label_path)
+                except:
+                    print(
+                        f"failed to read domain B label %s for image %s"
+                        % (B_label_path, N_img_path)
+                    )
+
+                B, B_label = self.transform(B_img, B_label)
+                if torch.any(B_label > self.semantic_nclasses - 1):
+                    warnings.warn(
+                        f"A label is above number of semantic classes for img {B_img_path} and label {B_label_path}, label is clamped to have only {self.semantic_nclasses} classes."
+                    )
+                    B_label = torch.clamp(B_label, max=self.semantic_nclasses - 1)
+            else:
+                B = self.transform_noseg(B_img)
+                B_label = []
 
             return {
                 "A": A,

--- a/data/unaligned_labeled_mask_online_dataset.py
+++ b/data/unaligned_labeled_mask_online_dataset.py
@@ -228,21 +228,14 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
             )
 
         except Exception as e:
-            print(
-                "failure with loading A domain image ",
-                A_img_path,
-                " or label ",
-                A_label_path,
-            )
-            print(e)
+            print(e, "domain A data loading")
             return None
 
         A, A_label = self.transform(A_img, A_label)
 
         if torch.any(A_label > self.semantic_nclasses - 1):
             warnings.warn(
-                "A label is above number of semantic classes for img %s and label %s"
-                % (A_img_path, A_label_path)
+                f"A label is above number of semantic classes for img {A_img_path} and label {A_label_path}, label is clamped to have only {self.semantic_nclasses} classes."
             )
             A_label = torch.clamp(A_label, max=self.semantic_nclasses - 1)
 
@@ -265,8 +258,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                     B, B_label = self.transform(B_img, B_label)
                     if torch.any(B_label > self.semantic_nclasses - 1):
                         warnings.warn(
-                            "A label is above number of semantic classes for img %s and label %s"
-                            % (B_img_path, B_label_path)
+                            f"A label is above number of semantic classes for img {B_img_path} and label {B_label_path}, label is clamped to have only {self.semantic_nclasses} classes."
                         )
                         B_label = torch.clamp(B_label, max=self.semantic_nclasses - 1)
 
@@ -279,13 +271,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                     B_label = []
 
             except Exception as e:
-                print(
-                    "failure with loading B domain image ",
-                    B_img_path,
-                    "or label",
-                    B_label_path,
-                )
-                print(e)
+                print(e, "domain B data loading")
                 return None
 
             return {

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -98,6 +98,9 @@ class BaseOptions:
             "--phase", type=str, default="train", help="train, val, test, etc"
         )
         parser.add_argument("--ddp_port", type=str, default="12355")
+        parser.add_argument(
+            "--warning_mode", action="store_true", help="whether to display warning"
+        )
 
         # model parameters
         parser.add_argument(

--- a/train.py
+++ b/train.py
@@ -34,6 +34,7 @@ import torch.distributed as dist
 import signal
 import torch
 import json
+import warnings
 
 
 def setup(rank, world_size, port):
@@ -59,6 +60,10 @@ def signal_handler(sig, frame):
 
 
 def train_gpu(rank, world_size, opt, dataset, dataset_temporal):
+
+    if not opt.warning_mode:
+        warnings.simplefilter("ignore")
+
     torch.cuda.set_device(opt.gpu_ids[rank])
     signal.signal(signal.SIGINT, signal_handler)  # to really kill the process
     signal.signal(signal.SIGTERM, signal_handler)
@@ -271,6 +276,9 @@ def launch_training(opt=None):
         opt = TrainOptions().parse()  # get training options
     opt.jg_dir = os.path.join("/".join(__file__.split("/")[:-1]))
     world_size = len(opt.gpu_ids)
+
+    if not opt.warning_mode:
+        warnings.simplefilter("ignore")
 
     dataset = create_dataset(opt)
     print("The number of training images = %d" % len(dataset))


### PR DESCRIPTION
Changes in dataloader to only reject an image when the path in not valid (for image or label). 
Any problem in data pre-processing (such as cropping dimension too small, label greater than the number of classes...) will be automatically resolved and a warning is printed in the logs.

There is a no warning mode. 