### PR TITLE
fix: inverted BtoA direction labels, moving direction to datasets

### DIFF
--- a/data/aligned_dataset.py
+++ b/data/aligned_dataset.py
@@ -25,16 +25,6 @@ class AlignedDataset(BaseDataset):
         assert (
             self.opt.data_load_size >= self.opt.data_crop_size
         )  # crop_size should be smaller than the size of loaded image
-        self.input_nc = (
-            self.opt.model_output_nc
-            if self.opt.data_direction == "BtoA"
-            else self.opt.model_input_nc
-        )
-        self.output_nc = (
-            self.opt.model_input_nc
-            if self.opt.data_direction == "BtoA"
-            else self.opt.model_output_nc
-        )
 
     def __getitem__(self, index):
         """Return a data point and its metadata information.

--- a/data/base_dataset.py
+++ b/data/base_dataset.py
@@ -38,6 +38,7 @@ class BaseDataset(data.Dataset, ABC):
         self.root = opt.dataroot
         self.sv_dir = os.path.join(opt.checkpoints_dir, opt.name)
         self.warning_mode = self.opt.warning_mode
+        self.set_dataset_dirs_and_dims()
 
     @staticmethod
     def modify_commandline_options(parser, is_train):
@@ -107,6 +108,30 @@ class BaseDataset(data.Dataset, ABC):
                 B_label_path = os.path.join(self.root, B_label_path)
 
         return self.get_img(A_img_path, A_label_path, B_img_path, B_label_path, index)
+
+    def set_dataset_dirs_and_dims(self):
+        btoA = self.opt.data_direction == "BtoA"
+        self.input_nc = (
+            self.opt.model_output_nc if btoA else self.opt.model_input_nc
+        )  # get the number of channels of input image
+        self.output_nc = (
+            self.opt.model_input_nc if btoA else self.opt.model_output_nc
+        )  # get the number of channels of output image
+
+        if not btoA:
+            self.dir_A = os.path.join(
+                self.opt.dataroot, self.opt.phase + "A"
+            )  # create a path '/path/to/data/trainA'
+            self.dir_B = os.path.join(
+                self.opt.dataroot, self.opt.phase + "B"
+            )  # create a path '/path/to/data/trainB'
+        else:
+            self.dir_A = os.path.join(
+                self.opt.dataroot, self.opt.phase + "B"
+            )  # create a path '/path/to/data/trainB'
+            self.dir_B = os.path.join(
+                self.opt.dataroot, self.opt.phase + "A"
+            )  # create a path '/path/to/data/trainA'
 
     def get_validation_set(self, size):
         return_A_list = []

--- a/data/colorization_dataset.py
+++ b/data/colorization_dataset.py
@@ -27,7 +27,7 @@ class ColorizationDataset(BaseDataset):
         By default, the number of channels for input image  is 1 (L) and
         the number of channels for output image is 2 (ab). The direction is from A to B
         """
-        parser.set_defaults(input_nc=1, output_nc=2, direction="AtoB")
+        parser.set_defaults(self.input_nc=1, self.output_nc=2, direction="AtoB")
         return parser
 
     def __init__(self, opt):
@@ -39,7 +39,6 @@ class ColorizationDataset(BaseDataset):
         BaseDataset.__init__(self, opt)
         self.dir = os.path.join(opt.dataroot, opt.phase)
         self.AB_paths = sorted(make_dataset(self.dir, opt.max_dataset_size))
-        assert opt.input_nc == 1 and opt.output_nc == 2 and opt.direction == "AtoB"
         self.transform = get_transform(self.opt, convert=False)
 
     def __getitem__(self, index):

--- a/data/nuplet_unaligned_labeled_mask_dataset.py
+++ b/data/nuplet_unaligned_labeled_mask_dataset.py
@@ -39,20 +39,6 @@ class NupletUnalignedLabeledMaskDataset(BaseDataset):
 
         self.nuplet_size = self.opt.nuplet_size
 
-        btoA = self.opt.direction == "BtoA"
-        self.input_nc = (
-            self.opt.output_nc if btoA else self.opt.input_nc
-        )  # get the number of channels of input image
-        output_nc = (
-            self.opt.input_nc if btoA else self.opt.output_nc
-        )  # get the number of channels of output image
-
-        self.dir_A = os.path.join(
-            opt.dataroot, opt.phase + "A"
-        )  # create a path '/path/to/data/trainA'
-        self.dir_B = os.path.join(
-            opt.dataroot, opt.phase + "B"
-        )  # create a path '/path/to/data/trainB'
         if os.path.exists(self.dir_A):
             self.A_img_paths, self.A_label_paths = make_labeled_mask_dataset(
                 self.dir_A, "/paths.txt", opt.max_dataset_size

--- a/data/single_dataset.py
+++ b/data/single_dataset.py
@@ -17,10 +17,7 @@ class SingleDataset(BaseDataset):
         """
         BaseDataset.__init__(self, opt)
         self.A_paths = sorted(make_dataset(opt.dataroot, opt.max_dataset_size))
-        input_nc = (
-            self.opt.output_nc if self.opt.direction == "BtoA" else self.opt.input_nc
-        )
-        self.transform = get_transform(opt, grayscale=(input_nc == 1))
+        self.transform = get_transform(opt, grayscale=(self.input_nc == 1))
 
     def __getitem__(self, index):
         """Return a data point and its metadata information.

--- a/data/temporal_dataset.py
+++ b/data/temporal_dataset.py
@@ -23,21 +23,6 @@ class TemporalDataset(BaseDataset):
     def __init__(self, opt):
         BaseDataset.__init__(self, opt)
         super(TemporalDataset).__init__()
-        self.opt = opt
-        btoA = self.opt.data_direction == "BtoA"
-        self.input_nc = (
-            self.opt.model_output_nc if btoA else self.opt.model_input_nc
-        )  # get the number of channels of input image
-        output_nc = (
-            self.opt.model_input_nc if btoA else self.opt.model_output_nc
-        )  # get the number of channels of output image
-
-        self.dir_A = os.path.join(
-            opt.dataroot, opt.phase + "A"
-        )  # create a path '/path/to/data/trainA'
-        self.dir_B = os.path.join(
-            opt.dataroot, opt.phase + "B"
-        )  # create a path '/path/to/data/trainB'
 
         self.A_img_paths, self.A_label_paths = make_labeled_path_dataset(
             self.dir_A, "/paths.txt"

--- a/data/unaligned_dataset.py
+++ b/data/unaligned_dataset.py
@@ -23,12 +23,6 @@ class UnalignedDataset(BaseDataset):
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
         BaseDataset.__init__(self, opt)
-        self.dir_A = os.path.join(
-            opt.dataroot, opt.phase + "A"
-        )  # create a path '/path/to/data/trainA'
-        self.dir_B = os.path.join(
-            opt.dataroot, opt.phase + "B"
-        )  # create a path '/path/to/data/trainB'
 
         self.dir_A_val = os.path.join(
             opt.dataroot, "validationA"
@@ -56,15 +50,9 @@ class UnalignedDataset(BaseDataset):
 
         self.A_size = len(self.A_img_paths)  # get the size of dataset A
         self.B_size = len(self.B_img_paths)  # get the size of dataset B
-        btoA = self.opt.data_direction == "BtoA"
-        input_nc = (
-            self.opt.model_output_nc if btoA else self.opt.model_input_nc
-        )  # get the number of channels of input image
-        output_nc = (
-            self.opt.model_input_nc if btoA else self.opt.model_output_nc
-        )  # get the number of channels of output image
-        self.transform_A = get_transform(self.opt, grayscale=(input_nc == 1))
-        self.transform_B = get_transform(self.opt, grayscale=(output_nc == 1))
+
+        self.transform_A = get_transform(self.opt, grayscale=(self.input_nc == 1))
+        self.transform_B = get_transform(self.opt, grayscale=(self.output_nc == 1))
 
     # A_label_path and B_label_path are unused
     def get_img(

--- a/data/unaligned_labeled_dataset.py
+++ b/data/unaligned_labeled_dataset.py
@@ -34,12 +34,6 @@ class UnalignedLabeledDataset(BaseDataset):
             opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
         """
         BaseDataset.__init__(self, opt)
-        self.dir_A = os.path.join(
-            opt.dataroot, opt.phase + "A"
-        )  # create a path '/path/to/data/trainA'
-        self.dir_B = os.path.join(
-            opt.dataroot, opt.phase + "B"
-        )  # create a path '/path/to/data/trainB'
 
         if not os.path.isfile(self.dir_A + "/paths.txt"):
             self.A_img_paths, self.A_label = make_labeled_dataset(
@@ -72,15 +66,9 @@ class UnalignedLabeledDataset(BaseDataset):
 
         self.A_size = len(self.A_img_paths)  # get the size of dataset A
         self.B_size = len(self.B_img_paths)  # get the size of dataset B
-        btoA = self.opt.data_direction == "BtoA"
-        input_nc = (
-            self.opt.model_output_nc if btoA else self.opt.model_input_nc
-        )  # get the number of channels of input image
-        output_nc = (
-            self.opt.model_input_nc if btoA else self.opt.model_output_nc
-        )  # get the number of channels of output image
-        self.transform_A = get_transform(self.opt, grayscale=(input_nc == 1))
-        self.transform_B = get_transform(self.opt, grayscale=(output_nc == 1))
+
+        self.transform_A = get_transform(self.opt, grayscale=(self.input_nc == 1))
+        self.transform_B = get_transform(self.opt, grayscale=(self.output_nc == 1))
 
         self.semantic_nclasses = self.opt.f_s_semantic_nclasses
 

--- a/data/unaligned_labeled_mask_dataset.py
+++ b/data/unaligned_labeled_mask_dataset.py
@@ -32,20 +32,6 @@ class UnalignedLabeledMaskDataset(BaseDataset):
         """
         BaseDataset.__init__(self, opt)
 
-        btoA = self.opt.data_direction == "BtoA"
-        self.input_nc = (
-            self.opt.model_output_nc if btoA else self.opt.model_input_nc
-        )  # get the number of channels of input image
-        output_nc = (
-            self.opt.model_input_nc if btoA else self.opt.model_output_nc
-        )  # get the number of channels of output image
-
-        self.dir_A = os.path.join(
-            opt.dataroot, opt.phase + "A"
-        )  # create a path '/path/to/data/trainA'
-        self.dir_B = os.path.join(
-            opt.dataroot, opt.phase + "B"
-        )  # create a path '/path/to/data/trainB'
         if os.path.exists(self.dir_A):
             self.A_img_paths, self.A_label_paths = make_labeled_path_dataset(
                 self.dir_A, "/paths.txt", opt.data_max_dataset_size

--- a/data/unaligned_labeled_mask_online_dataset.py
+++ b/data/unaligned_labeled_mask_online_dataset.py
@@ -33,20 +33,6 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
         """
         BaseDataset.__init__(self, opt)
 
-        btoA = self.opt.data_direction == "BtoA"
-        self.input_nc = (
-            self.opt.model_output_nc if btoA else self.opt.model_input_nc
-        )  # get the number of channels of input image
-        output_nc = (
-            self.opt.model_input_nc if btoA else self.opt.model_output_nc
-        )  # get the number of channels of output image
-
-        self.dir_A = os.path.join(
-            opt.dataroot, opt.phase + "A"
-        )  # create a path '/path/to/data/trainA'
-        self.dir_B = os.path.join(
-            opt.dataroot, opt.phase + "B"
-        )  # create a path '/path/to/data/trainB'
         if os.path.exists(self.dir_A):
             self.A_img_paths, self.A_label_paths = make_labeled_path_dataset(
                 self.dir_A, "/paths.txt"

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -243,8 +243,7 @@ class BaseModel(ABC):
             input (dict): include the data itself and its metadata information.
         The option 'direction' can be used to swap domain A and domain B.
         """
-        AtoB = self.opt.data_direction == "AtoB"
-        self.real_A_with_context = input["A" if AtoB else "B"].to(self.device)
+        self.real_A_with_context = input["A"].to(self.device)
         self.real_A = self.real_A_with_context.clone()
         if self.opt.data_online_context_pixels > 0:
             self.real_A = self.real_A[
@@ -258,7 +257,7 @@ class BaseModel(ABC):
                 self.real_A_with_context, size=self.real_A.shape[2:]
             )
 
-        self.real_B_with_context = input["B" if AtoB else "A"].to(self.device)
+        self.real_B_with_context = input["B"].to(self.device)
 
         self.real_B = self.real_B_with_context.clone()
 
@@ -274,17 +273,12 @@ class BaseModel(ABC):
             self.real_B_with_context, size=self.real_A.shape[2:]
         )
 
-        self.image_paths = input["A_img_paths" if AtoB else "B_img_paths"]
+        self.image_paths = input["A_img_paths"]
 
     def set_input_temporal(self, input_temporal):
 
-        AtoB = self.opt.data_direction == "AtoB"
-        self.temporal_real_A_with_context = input_temporal["A" if AtoB else "B"].to(
-            self.device
-        )
-        self.temporal_real_B_with_context = input_temporal["B" if AtoB else "A"].to(
-            self.device
-        )
+        self.temporal_real_A_with_context = input_temporal["A"]
+        self.temporal_real_B_with_context = input_temporal["B"]
 
         if self.opt.data_online_context_pixels > 0:
 


### PR DESCRIPTION
Using BtoA was providing inverted labels to the semantics. This PR fixes it by definitely moving dataset direction out of models, into datasets.