### PR TITLE
feat: multiple D via vision aided ensembling, https://arxiv.org/abs/2112.09130

### DIFF
--- a/docker/Dockerfile.devel
+++ b/docker/Dockerfile.devel
@@ -12,6 +12,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     python3-pytest \
     sudo \
     wget \
+    git \
     unzip
 
 USER jenkins

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -702,7 +702,9 @@ class BaseModel(ABC):
         for net in nets:
             if net is not None:
                 for name, param in net.named_parameters():
-                    if not "freeze" in name:
+                    if (
+                        not "freeze" in name and not "cv_ensemble" in name
+                    ):  # cv_ensemble is for vision-aided
                         param.requires_grad = requires_grad
                     else:
                         param.requires_grad = False
@@ -1207,11 +1209,12 @@ class BaseModel(ABC):
 
             loss_calculator_name = "D_" + discriminator_name + "_loss_calculator"
 
-            train_gan_mode = (
-                "projected"
-                if "temporal" in discriminator_name or "projected" in discriminator_name
-                else self.opt.train_gan_mode
-            )
+            if "temporal" in discriminator_name or "projected" in discriminator_name:
+                train_gan_mode = "projected"
+            elif "vision_aided" in discriminator_name:
+                train_gan_mode = "vanilla"
+            else:
+                train_gan_mode = self.opt.train_gan_mode
 
             if "temporal" in discriminator_name:
                 setattr(

--- a/models/modules/discriminators.py
+++ b/models/modules/discriminators.py
@@ -1,4 +1,3 @@
-import argparse
 import functools
 
 import numpy as np

--- a/models/modules/vision_aided_d.py
+++ b/models/modules/vision_aided_d.py
@@ -1,0 +1,23 @@
+import torch
+from torch import nn
+import vision_aided_loss
+
+
+class VisionAidedDiscriminator(nn.Module):
+    """Defines a vision-aided discriminator"""
+
+    def __init__(
+        self,
+        cv_type="clip+dino",
+    ):
+        super(VisionAidedDiscriminator, self).__init__()
+        loss_type = ""  # loss is computed elsewhere
+        self.model = vision_aided_loss.Discriminator(
+            cv_type,
+            loss_type,
+            device=torch.device("cuda" if torch.cuda.is_available() else "cpu"),
+        )
+        self.model.cv_ensemble.requires_grad_(False)  # freeze feature extractor
+
+    def forward(self, input):
+        return self.model(input)[0]

--- a/models/networks.py
+++ b/models/networks.py
@@ -38,6 +38,7 @@ from .modules.projected_d.discriminator import (
     ProjectedDiscriminator,
     TemporalProjectedDiscriminator,
 )
+from .modules.vision_aided_d import VisionAidedDiscriminator
 from .modules.segformer.segformer_generator import Segformer, SegformerGenerator_attn
 
 
@@ -277,6 +278,7 @@ def define_D(
     D_temporal_number_frames,
     D_temporal_frame_step,
     data_online_context_pixels,
+    D_vision_aided_backbones,
     **unused_options
 ):
 
@@ -364,7 +366,7 @@ def define_D(
                 model_input_nc,
                 D_ndf,
                 nclasses,
-                opt.data_crop_size + margin,
+                data_crop_size + margin,
                 template,
                 pretrained=False,
             )
@@ -384,7 +386,11 @@ def define_D(
                 weight_path=weight_path,
                 img_size=data_crop_size + margin,
             )
-            return_nets[netD] = net  # no init since custom frozen backbon
+            return_nets[netD] = net  # no init since custom frozen backbone
+
+        elif netD == "vision_aided":
+            net = VisionAidedDiscriminator(cv_type=D_vision_aided_backbones)
+            return_nets[netD] = net  # no init since partly frozen
 
         elif netD == "temporal":
             # projected D temporal

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -238,12 +238,18 @@ class BaseOptions:
                 "smallpatchstylegan2",
                 "projected_d",
                 "temporal",
+                "vision_aided",
             ]
             + list(TORCH_MODEL_CLASSES.keys()),
             help="specify discriminator architecture, D_n_layers allows you to specify the layers in the discriminator. NB: duplicated arguments will be ignored.",
             nargs="+",
         )
-
+        parser.add_argument(
+            "--D_vision_aided_backbones",
+            type=str,
+            default="clip+dino",
+            help="specify discriminators architectures, they are frozen then output are combined and fitted with a linear network on top, choose from dino, clip, swin, det_coco, seg_ade and combine them with +",
+        )
         parser.add_argument(
             "--D_n_layers", type=int, default=3, help="only used if netD==n_layers"
         )

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ imgaug
 dominate
 wget
 tqdm
+git+https://github.com/nupurkmr9/vision-aided-gan.git


### PR DESCRIPTION
This PR adds so-called vision-aided discriminators from https://github.com/nupurkmr9/vision-aided-gan.

In practice this allows adding up multiple large discriminators backbones that are lightly linearly fitted on top. This is akin our projected discriminators, though lighter. We expect them to speed up training even more.

New options:
- in `--D_netDs`: `vision_aided`
- `--D_vision_aided_backbones` to possibly add multiple. 

However, note that the linear probing and progressive ensembling that is at the core of the paper appears to be somehow custom to each GAN, and thus is not used here. The addition of more Ds appears useful though given the current and very initial training runs we have.