### PR TITLE
fix: segformer for semantics with optional partially pre-trained model

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -379,8 +379,8 @@ class BaseOptions:
         parser.add_argument(
             "--f_s_weight_segformer",
             type=str,
-            default="models/configs/segformer/pretrain/segformer_mit-b0.pth",
-            help="path to segformer weight for f_s",
+            default="",
+            help="path to segformer weight for f_s, e.g. models/configs/segformer/pretrain/segformer_mit-b0.pth",
         )
 
         # dataset parameters


### PR DESCRIPTION
This PR :
- fixes broken usage of segformer for semantics
- allows using a partially trained model by skipping the pretrained `decode_head`

Note: it'd be better to have a generic `load_partial_state_dict` function in `models/modules/utils.py` cc @pnsuau 