### PR TITLE
feat: directional clip loss as semantic constraint

### DIFF
--- a/.github/workflows/requirements_github_actions.txt
+++ b/.github/workflows/requirements_github_actions.txt
@@ -13,3 +13,4 @@ wget
 git+https://github.com/nupurkmr9/vision-aided-gan.git
 mmsegmentation==0.22.1
 mmcv-full==1.4.7
+git+https://github.com/openai/CLIP.git

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1202,21 +1202,25 @@ class BaseModel(ABC):
 
                 self.loss_G_tot += loss_value
 
-        # CLip styler loss
-        self.loss_G_clip_styler_AB = self.compute_clip_styler_loss(
-            real=self.real_A, fake=self.fake_B, text_direction=self.text_direction_AB
-        ).mean()
+        if self.opt.train_sem_clipstyler_loss:
 
-        self.loss_G_tot += self.loss_G_clip_styler_AB
-
-        if hasattr(self, "fake_A"):
-            self.loss_G_clip_styler_BA = self.compute_clip_styler_loss(
-                real=self.real_B,
-                fake=self.fake_A,
-                text_direction=self.text_direction_BA,
+            # CLip styler loss
+            self.loss_G_clip_styler_AB = self.compute_clip_styler_loss(
+                real=self.real_A,
+                fake=self.fake_B,
+                text_direction=self.text_direction_AB,
             ).mean()
 
-            self.loss_G_tot += self.loss_G_clip_styler_BA.mean()
+            self.loss_G_tot += self.loss_G_clip_styler_AB
+
+            if hasattr(self, "fake_A"):
+                self.loss_G_clip_styler_BA = self.compute_clip_styler_loss(
+                    real=self.real_B,
+                    fake=self.fake_A,
+                    text_direction=self.text_direction_BA,
+                ).mean()
+
+                self.loss_G_tot += self.loss_G_clip_styler_BA.mean()
 
     def compute_fid_val(self):
         dims = 2048

--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -276,7 +276,7 @@ class CUTModel(BaseModel):
             losses_G.append(discriminator.loss_name_G)
             losses_D.append(discriminator.loss_name_D)
 
-        self.loss_names_G = losses_G
+        self.loss_names_G += losses_G
         self.loss_names_D = losses_D
         if self.opt.model_multimodal:
             self.loss_names_E = losses_E
@@ -290,7 +290,6 @@ class CUTModel(BaseModel):
 
         # Itercalculator
         if self.opt.train_iter_size > 1:
-            print("cut loss_names=", self.loss_names)
             self.iter_calculator = IterCalculator(self.loss_names)
             for i, cur_loss in enumerate(self.loss_names):
                 self.loss_names[i] = cur_loss + "_avg"
@@ -306,6 +305,12 @@ class CUTModel(BaseModel):
             ]
 
             self.visual_names.append(self.context_visual_names)
+
+        if self.opt.train_sem_clipstyler_loss:
+            assert (
+                self.opt.train_sem_txt_label_A is not None
+                and self.opt.train_sem_txt_label_B is not None
+            )
 
     def set_input_first_gpu(self, data):
         self.set_input(data)

--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -228,8 +228,11 @@ class CycleGANModel(BaseModel):
                 losses_G.append(discriminator.loss_name_G)
                 losses_D.append(discriminator.loss_name_D)
 
-            self.loss_names_G = losses_G
+            self.loss_names_G += losses_G
             self.loss_names_D = losses_D
+
+            if self.opt.train_sem_clipstyler_loss:
+                self.loss_names_G += ["G_clip_styler_BA"]
 
             self.loss_names = self.loss_names_G + self.loss_names_D
 
@@ -256,6 +259,15 @@ class CycleGANModel(BaseModel):
 
             self.visual_names.append(self.context_visual_names_A)
             self.visual_names.append(self.context_visual_names_B)
+
+        # Clipstyler direction B-> A
+
+        if self.opt.train_sem_clipstyler_loss:
+            self.text_direction_BA = (
+                self.feats_clip_txt_A - self.feats_clip_txt_B
+            ).repeat(self.opt.train_batch_size, 1)
+
+            self.text_direction_BA /= self.text_direction_BA.norm(dim=-1, keepdim=True)
 
     def forward(self):
         """Run forward pass; called by both functions <optimize_parameters> and <test>."""

--- a/models/modules/clip_loss.py
+++ b/models/modules/clip_loss.py
@@ -1,0 +1,124 @@
+import torch
+import clip
+import torch.nn.functional as F
+
+
+# TEXT
+
+
+def compute_feats_clip_txt(label, device, clip_model):
+    text = compose_text_with_templates(label, imagenet_templates)
+    tokens = clip.tokenize(text).to(device)
+    text_features = clip_model.encode_text(tokens).detach()
+    text_features = text_features.mean(axis=0, keepdim=True)
+    text_features /= text_features.norm(dim=-1, keepdim=True)
+
+    return text_features
+
+
+imagenet_templates = [
+    "a bad photo of a {}.",
+    "a sculpture of a {}.",
+    "a photo of the hard to see {}.",
+    "a low resolution photo of the {}.",
+    "a rendering of a {}.",
+    "graffiti of a {}.",
+    "a bad photo of the {}.",
+    "a cropped photo of the {}.",
+    "a tattoo of a {}.",
+    "the embroidered {}.",
+    "a photo of a hard to see {}.",
+    "a bright photo of a {}.",
+    "a photo of a clean {}.",
+    "a photo of a dirty {}.",
+    "a dark photo of the {}.",
+    "a drawing of a {}.",
+    "a photo of my {}.",
+    "the plastic {}.",
+    "a photo of the cool {}.",
+    "a close-up photo of a {}.",
+    "a black and white photo of the {}.",
+    "a painting of the {}.",
+    "a painting of a {}.",
+    "a pixelated photo of the {}.",
+    "a sculpture of the {}.",
+    "a bright photo of the {}.",
+    "a cropped photo of a {}.",
+    "a plastic {}.",
+    "a photo of the dirty {}.",
+    "a jpeg corrupted photo of a {}.",
+    "a blurry photo of the {}.",
+    "a photo of the {}.",
+    "a good photo of the {}.",
+    "a rendering of the {}.",
+    "a {} in a video game.",
+    "a photo of one {}.",
+    "a doodle of a {}.",
+    "a close-up photo of the {}.",
+    "a photo of a {}.",
+    "the origami {}.",
+    "the {} in a video game.",
+    "a sketch of a {}.",
+    "a doodle of the {}.",
+    "a origami {}.",
+    "a low resolution photo of a {}.",
+    "the toy {}.",
+    "a rendition of the {}.",
+    "a photo of the clean {}.",
+    "a photo of a large {}.",
+    "a rendition of a {}.",
+    "a photo of a nice {}.",
+    "a photo of a weird {}.",
+    "a blurry photo of a {}.",
+    "a cartoon {}.",
+    "art of a {}.",
+    "a sketch of the {}.",
+    "a embroidered {}.",
+    "a pixelated photo of a {}.",
+    "itap of the {}.",
+    "a jpeg corrupted photo of the {}.",
+    "a good photo of a {}.",
+    "a plushie {}.",
+    "a photo of the nice {}.",
+    "a photo of the small {}.",
+    "a photo of the weird {}.",
+    "the cartoon {}.",
+    "art of the {}.",
+    "a drawing of the {}.",
+    "a photo of the large {}.",
+    "a black and white photo of a {}.",
+    "the plushie {}.",
+    "a dark photo of a {}.",
+    "itap of a {}.",
+    "graffiti of the {}.",
+    "a toy {}.",
+    "itap of my {}.",
+    "a photo of a cool {}.",
+    "a photo of a small {}.",
+    "a tattoo of the {}.",
+]
+
+
+def compose_text_with_templates(text: str, templates=imagenet_templates) -> list:
+    return [template.format(text) for template in templates]
+
+
+# IMAGE
+
+
+def compute_feats_clip_img(image, device, clip_model):
+    features = clip_model.encode_image(clip_normalize(image, device))
+    features /= source_features.clone().norm(dim=-1, keepdim=True)
+
+    return features
+
+
+def clip_normalize(image, device):
+    image = F.interpolate(image, size=224, mode="bicubic")
+    mean = torch.tensor([0.48145466, 0.4578275, 0.40821073]).to(device)
+    std = torch.tensor([0.26862954, 0.26130258, 0.27577711]).to(device)
+    mean = mean.view(1, -1, 1, 1)
+    std = std.view(1, -1, 1, 1)
+
+    image = (image - mean) / std
+    return image

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -292,6 +292,26 @@ class TrainOptions(BaseOptions):
             help="if true apply generator semantic loss on network output for real image rather than on label.",
         )
 
+        parser.add_argument(
+            "--train_sem_txt_label_A",
+            type=str,
+            default=None,
+            help="Text label for clipstyler loss for domain A",
+        )
+
+        parser.add_argument(
+            "--train_sem_txt_label_B",
+            type=str,
+            default=None,
+            help="Text label for clipstyler loss for domain B",
+        )
+
+        parser.add_argument(
+            "--train_sem_clipstyler_loss",
+            action="store_true",
+            help="if true apply clipstyler loss",
+        )
+
         # train with mask semantics
         parser.add_argument(
             "--train_mask_f_s_B",

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,4 @@ dominate
 wget
 tqdm
 git+https://github.com/nupurkmr9/vision-aided-gan.git
+git+https://github.com/openai/CLIP.git


### PR DESCRIPTION
Implementation of Clipstyler loss from https://github.com/cyclomon/CLIPstyler (only on whole images cf https://stylegan-nada.github.io/ not on patches).
Each domain text label is composed of a word (apples,oranges eg) or a group of words (cloudy sky eg)

New options:
- `--train_sem_clip_directional_loss` ; whether to use clip directional loss
- `--train_sem_txt_label_A` : label for domain A
- `--train_sem_txt_label_B` : label for domain B
- `--train_sem_clip_direction_template` : path to templates file

Usage
``` 
python3 train.py  --train_sem_clipstyler_loss --train_sem_txt_label_A apples --train_sem_txt_label_B oranges 