### PR TITLE
feat: option to compute semantic G loss on f_s output

### DIFF
--- a/models/cut_semantic_mask_model.py
+++ b/models/cut_semantic_mask_model.py
@@ -224,6 +224,8 @@ class CUTSemanticMaskModel(CUTModel):
         super().compute_G_loss()
         if self.opt.train_mask_for_removal:
             label_fake_B = torch.zeros_like(self.input_A_label)
+        elif self.opt.train_sem_net_output:
+            label_fake_B = self.gt_pred_real_A
         else:
             label_fake_B = self.input_A_label
 
@@ -232,9 +234,15 @@ class CUTSemanticMaskModel(CUTModel):
         )
 
         if self.opt.train_sem_idt:
+            if self.opt.train_mask_for_removal:
+                label_idt_B = torch.zeros_like(self.input_A_label)
+            elif self.opt.train_sem_net_output or not hasattr(self, "input_B_label"):
+                label_idt_B = self.gt_pred_real_B
+            else:
+                label_idt_B = self.input_B_label
 
             self.loss_G_sem_idt = self.opt.train_sem_lambda * self.criterionf_s(
-                self.pred_idt_B, self.input_B_label
+                self.pred_idt_B, label_idt_B
             )
 
         if (

--- a/models/cycle_gan_semantic_mask_model.py
+++ b/models/cycle_gan_semantic_mask_model.py
@@ -301,32 +301,35 @@ class CycleGANSemanticMaskModel(CycleGANModel):
         super().compute_G_loss()
 
         # semantic loss AB
+        if self.opt.train_sem_net_output:
+            label_fake_B = self.gt_pred_A
+        else:
+            label_fake_B = self.input_A_label
         self.loss_G_sem_AB = self.opt.train_sem_lambda * self.criterionf_s(
-            self.pred_fake_B, self.input_A_label
+            self.pred_fake_B, label_fake_B
         )
 
         # semantic loss BA
-        if hasattr(self, "input_B_label"):
-            self.loss_G_sem_BA = self.opt.train_sem_lambda * self.criterionf_s(
-                self.pred_fake_A, self.input_B_label
-            )  # .squeeze(1))
+        if self.opt.train_sem_net_output or not hasattr(self, "input_B_label"):
+            label_fake_A = self.gt_pred_B
         else:
-            self.loss_G_sem_BA = self.opt.train_sem_lambda * self.criterionf_s(
-                self.pred_fake_A, self.gt_pred_B
-            )  # .squeeze(1))
+            label_fake_A = self.input_B_label
+        self.loss_G_sem_BA = self.opt.train_sem_lambda * self.criterionf_s(
+            self.pred_fake_A, label_fake_A
+        )
 
         if self.opt.train_sem_idt:
 
             # semantic loss idt A
-
+            label_idt_A = label_fake_B
             self.loss_G_sem_idt_A = self.opt.train_sem_lambda * self.criterionf_s(
-                self.pred_idt_A, self.input_A_label
+                self.pred_idt_A, label_idt_A
             )
 
             # semantic loss idt B
-
+            label_idt_B = label_fake_A
             self.loss_G_sem_idt_B = self.opt.train_sem_lambda * self.criterionf_s(
-                self.pred_idt_B, self.input_B_label
+                self.pred_idt_B, label_idt_B
             )
 
         # only use semantic loss when classifier has reasonably low loss

--- a/options/train_options.py
+++ b/options/train_options.py
@@ -286,6 +286,12 @@ class TrainOptions(BaseOptions):
             help="if true apply semantic loss on identity",
         )
 
+        parser.add_argument(
+            "--train_sem_net_output",
+            action="store_true",
+            help="if true apply generator semantic loss on network output for real image rather than on label.",
+        )
+
         # train with mask semantics
         parser.add_argument(
             "--train_mask_f_s_B",


### PR DESCRIPTION
Option to compute semantic G loss on f_s outputs rather than on labels.

Usage:
```python train.py --train_sem_net_output```