### PR TITLE
fix: input_B_label loading when available

### DIFF
--- a/models/cut_semantic_mask_model.py
+++ b/models/cut_semantic_mask_model.py
@@ -169,7 +169,7 @@ class CUTSemanticMaskModel(CUTModel):
                     self.opt.data_online_context_pixels : -self.opt.data_online_context_pixels,
                 ]
 
-        if self.opt.train_mask_f_s_B and "B_label" in input:
+        if "B_label" in input:
             self.input_B_label = input["B_label"].to(self.device).squeeze(1)
 
             if self.opt.data_online_context_pixels > 0:


### PR DESCRIPTION
Domain B labels are now loaded when they are available, no matter what are the training options. (for cur_semantic_mask model)