### PR TITLE
fix : f_s_class_weights default to []

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -375,7 +375,7 @@ class BaseOptions:
         )
         parser.add_argument(
             "--f_s_class_weights",
-            default=None,
+            default=[],
             nargs="*",
             type=int,
             help="class weights for imbalanced semantic classes",


### PR DESCRIPTION
Change `f_s_class_weights` default to `[]` in order to avoid joligan server crash (during `BaseOptions` `parse_json` method).