### PR TITLE
feat: support for amp on forward ops

### DIFF
--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -312,7 +312,7 @@ class CUTModel(BaseModel):
         if self.opt.train_semantic_cls:
             self.init_semantic_cls(opt)
 
-        self.backward_functions_G.append("compute_G_loss_cut")
+        self.loss_functions_G.append("compute_G_loss_cut")
         self.forward_functions.insert(1, "forward_cut")
 
         # Itercalculator

--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -238,7 +238,7 @@ class CycleGanModel(BaseModel):
         if self.opt.train_semantic_cls:
             self.init_semantic_cls(opt)
 
-        self.backward_functions_G.append("compute_G_loss_cycle_gan")
+        self.loss_functions_G.append("compute_G_loss_cycle_gan")
         self.forward_functions.insert(1, "forward_cycle_gan")
 
         # Itercalculator

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -90,6 +90,11 @@ class BaseOptions:
             help="gpu ids: e.g. 0  0,1,2, 0,2. use -1 for CPU",
         )
         parser.add_argument(
+            "--with_amp",
+            action="store_true",
+            help="whether to activate torch amp on forward passes",
+        )
+        parser.add_argument(
             "--checkpoints_dir",
             type=str,
             default="./checkpoints",


### PR DESCRIPTION
Support for amp mixed precision / cuda tensorcores with `--with_amp`.
I measure ~20% faster per image at training time.
Note: this is active on forward passes only.