### PR TITLE
feat: unet diffusion generator

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -805,7 +805,7 @@ class BaseModel(ABC):
                 )
 
                 # onnx
-                if not "ittr" in self.opt.G_netG:
+                if not "ittr" in self.opt.G_netG and not "unet_mha" in self.opt.G_netG:
                     export_path_onnx = save_path.replace(".pth", ".onnx")
 
                     torch.onnx.export(

--- a/models/gan_networks.py
+++ b/models/gan_networks.py
@@ -42,6 +42,7 @@ from .modules.segformer.segformer_generator import (
 )
 from .modules.ittr.ittr_generator import ITTRGenerator
 from .modules.multimodal_encoder import E_ResNet, E_NLayers
+from .modules.unet_generator_attn.unet_generator_attn import UNet as UNet_mha
 
 
 def define_G(
@@ -63,6 +64,8 @@ def define_G(
     G_config_segformer,
     G_stylegan2_num_downsampling,
     G_backward_compatibility_twice_resnet_blocks,
+    G_unet_mha_inner_channel,
+    G_unet_mha_num_head_channels,
     **unused_options
 ):
     """Create a generator
@@ -207,6 +210,19 @@ def define_G(
             img_size=data_crop_size,
             n_blocks=3,
             ngf=G_ngf,
+        )
+        return net
+    elif G_netG == "unet_mha":
+        net = UNet_mha(
+            image_size=data_crop_size,
+            in_channel=model_input_nc,
+            inner_channel=G_unet_mha_inner_channel,  # e.g. 64 in palette repo
+            out_channel=model_output_nc,
+            res_blocks=G_nblocks,  # 2 in palette repo
+            attn_res=[16],  # e.g.
+            channel_mults=(1, 2, 4, 8),  # e.g.
+            num_head_channels=G_unet_mha_num_head_channels,  # e.g. 32 in palette repo
+            tanh=True,
         )
         return net
     else:

--- a/models/modules/unet_generator_attn/unet_attn_utils.py
+++ b/models/modules/unet_generator_attn/unet_attn_utils.py
@@ -1,0 +1,139 @@
+"""
+Various utilities for neural networks.
+"""
+
+import math
+import numpy as np
+import torch
+import torch.nn as nn
+
+
+class GroupNorm32(nn.GroupNorm):
+    def forward(self, x):
+        return super().forward(x.float()).type(x.dtype)
+
+
+def zero_module(module):
+    """
+    Zero out the parameters of a module and return it.
+    """
+    for p in module.parameters():
+        p.detach().zero_()
+    return module
+
+
+def scale_module(module, scale):
+    """
+    Scale the parameters of a module and return it.
+    """
+    for p in module.parameters():
+        p.detach().mul_(scale)
+    return module
+
+
+def mean_flat(tensor):
+    """
+    Take the mean over all non-batch dimensions.
+    """
+    return tensor.mean(dim=list(range(1, len(tensor.shape))))
+
+
+def normalization(channels):
+    """
+    Make a standard normalization layer.
+
+    :param channels: number of input channels.
+    :return: an nn.Module for normalization.
+    """
+    return GroupNorm32(32, channels)
+
+
+def checkpoint(func, inputs, params, flag):
+    """
+    Evaluate a function without caching intermediate activations, allowing for
+    reduced memory at the expense of extra compute in the backward pass.
+
+    :param func: the function to evaluate.
+    :param inputs: the argument sequence to pass to `func`.
+    :param params: a sequence of parameters `func` depends on but does not
+                   explicitly take as arguments.
+    :param flag: if False, disable gradient checkpointing.
+    """
+    if flag:
+        args = tuple(inputs) + tuple(params)
+        return CheckpointFunction.apply(func, len(inputs), *args)
+    else:
+        return func(*inputs)
+
+
+class CheckpointFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, run_function, length, *args):
+        ctx.run_function = run_function
+        ctx.input_tensors = list(args[:length])
+        ctx.input_params = list(args[length:])
+        with torch.no_grad():
+            output_tensors = ctx.run_function(*ctx.input_tensors)
+        return output_tensors
+
+    @staticmethod
+    def backward(ctx, *output_grads):
+        ctx.input_tensors = [x.detach().requires_grad_(True) for x in ctx.input_tensors]
+        with torch.enable_grad():
+            # Fixes a bug where the first op in run_function modifies the
+            # Tensor storage in place, which is not allowed for detach()'d
+            # Tensors.
+            shallow_copies = [x.view_as(x) for x in ctx.input_tensors]
+            output_tensors = ctx.run_function(*shallow_copies)
+        input_grads = torch.autograd.grad(
+            output_tensors,
+            ctx.input_tensors + ctx.input_params,
+            output_grads,
+            allow_unused=True,
+        )
+        del ctx.input_tensors
+        del ctx.input_params
+        del output_tensors
+        return (None, None) + input_grads
+
+
+def count_flops_attn(model, _x, y):
+    """
+    A counter for the `thop` package to count the operations in an
+    attention operation.
+    Meant to be used like:
+        macs, params = thop.profile(
+            model,
+            inputs=(inputs, timestamps),
+            custom_ops={QKVAttention: QKVAttention.count_flops},
+        )
+    """
+    b, c, *spatial = y[0].shape
+    num_spatial = int(np.prod(spatial))
+    # We perform two matmuls with the same number of ops.
+    # The first computes the weight matrix, the second computes
+    # the combination of the value vectors.
+    matmul_ops = 2 * b * (num_spatial**2) * c
+    model.total_ops += torch.DoubleTensor([matmul_ops])
+
+
+def gamma_embedding(gammas, dim, max_period=10000):
+    """
+    Create sinusoidal timestep embeddings.
+    :param gammas: a 1-D Tensor of N indices, one per batch element.
+                      These may be fractional.
+    :param dim: the dimension of the output.
+    :param max_period: controls the minimum frequency of the embeddings.
+    :return: an [N x dim] Tensor of positional embeddings.
+    """
+    half = dim // 2
+    freqs = torch.exp(
+        -math.log(max_period)
+        * torch.arange(start=0, end=half, dtype=torch.float32)
+        / half
+    ).to(device=gammas.device)
+    args = gammas[:, None].float() * freqs[None]
+    embedding = torch.cat([torch.cos(args), torch.sin(args)], dim=-1)
+    if dim % 2:
+        embedding = torch.cat([embedding, torch.zeros_like(embedding[:, :1])], dim=-1)
+    return embedding

--- a/models/modules/unet_generator_attn/unet_generator_attn.py
+++ b/models/modules/unet_generator_attn/unet_generator_attn.py
@@ -1,0 +1,594 @@
+from abc import abstractmethod
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .unet_attn_utils import (
+    checkpoint,
+    zero_module,
+    normalization,
+    count_flops_attn,
+    gamma_embedding,
+)
+
+
+class SiLU(nn.Module):
+    def forward(self, x):
+        return x * torch.sigmoid(x)
+
+
+class EmbedBlock(nn.Module):
+    """
+    Any module where forward() takes embeddings as a second argument.
+    """
+
+    @abstractmethod
+    def forward(self, x, emb):
+        """
+        Apply the module to `x` given `emb` embeddings.
+        """
+
+
+class EmbedSequential(nn.Sequential, EmbedBlock):
+    """
+    A sequential module that passes embeddings to the children that
+    support it as an extra input.
+    """
+
+    def forward(self, x, emb):
+        for layer in self:
+            if isinstance(layer, EmbedBlock):
+                x = layer(x, emb)
+            else:
+                x = layer(x)
+        return x
+
+
+class Upsample(nn.Module):
+    """
+    An upsampling layer with an optional convolution.
+    :param channels: channels in the inputs and outputs.
+    :param use_conv: a bool determining if a convolution is applied.
+
+    """
+
+    def __init__(self, channels, use_conv, out_channel=None):
+        super().__init__()
+        self.channels = channels
+        self.out_channel = out_channel or channels
+        self.use_conv = use_conv
+        if use_conv:
+            self.conv = nn.Conv2d(self.channels, self.out_channel, 3, padding=1)
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+        x = F.interpolate(x, scale_factor=2, mode="nearest")
+        if self.use_conv:
+            x = self.conv(x)
+        return x
+
+
+class Downsample(nn.Module):
+    """
+    A downsampling layer with an optional convolution.
+    :param channels: channels in the inputs and outputs.
+    :param use_conv: a bool determining if a convolution is applied.
+    """
+
+    def __init__(self, channels, use_conv, out_channel=None):
+        super().__init__()
+        self.channels = channels
+        self.out_channel = out_channel or channels
+        self.use_conv = use_conv
+        stride = 2
+        if use_conv:
+            self.op = nn.Conv2d(
+                self.channels, self.out_channel, 3, stride=stride, padding=1
+            )
+        else:
+            assert self.channels == self.out_channel
+            self.op = nn.AvgPool2d(kernel_size=stride, stride=stride)
+
+    def forward(self, x):
+        assert x.shape[1] == self.channels
+        return self.op(x)
+
+
+class ResBlock(EmbedBlock):
+    """
+    A residual block that can optionally change the number of channels.
+    :param channels: the number of input channels.
+    :param emb_channels: the number of embedding channels.
+    :param dropout: the rate of dropout.
+    :param out_channel: if specified, the number of out channels.
+    :param use_conv: if True and out_channel is specified, use a spatial
+        convolution instead of a smaller 1x1 convolution to change the
+        channels in the skip connection.
+    :param use_checkpoint: if True, use gradient checkpointing on this module.
+    :param up: if True, use this block for upsampling.
+    :param down: if True, use this block for downsampling.
+    """
+
+    def __init__(
+        self,
+        channels,
+        emb_channels,
+        dropout,
+        out_channel=None,
+        use_conv=False,
+        use_scale_shift_norm=False,
+        use_checkpoint=False,
+        up=False,
+        down=False,
+    ):
+        super().__init__()
+        self.channels = channels
+        self.emb_channels = emb_channels
+        self.dropout = dropout
+        self.out_channel = out_channel or channels
+        self.use_conv = use_conv
+        self.use_checkpoint = use_checkpoint
+        self.use_scale_shift_norm = use_scale_shift_norm
+
+        self.in_layers = nn.Sequential(
+            normalization(channels),
+            SiLU(),
+            nn.Conv2d(channels, self.out_channel, 3, padding=1),
+        )
+
+        self.updown = up or down
+
+        if up:
+            self.h_upd = Upsample(channels, False)
+            self.x_upd = Upsample(channels, False)
+        elif down:
+            self.h_upd = Downsample(channels, False)
+            self.x_upd = Downsample(channels, False)
+        else:
+            self.h_upd = self.x_upd = nn.Identity()
+
+        self.emb_layers = nn.Sequential(
+            SiLU(),
+            nn.Linear(
+                emb_channels,
+                2 * self.out_channel if use_scale_shift_norm else self.out_channel,
+            ),
+        )
+        self.out_layers = nn.Sequential(
+            normalization(self.out_channel),
+            SiLU(),
+            nn.Dropout(p=dropout),
+            zero_module(nn.Conv2d(self.out_channel, self.out_channel, 3, padding=1)),
+        )
+
+        if self.out_channel == channels:
+            self.skip_connection = nn.Identity()
+        elif use_conv:
+            self.skip_connection = nn.Conv2d(channels, self.out_channel, 3, padding=1)
+        else:
+            self.skip_connection = nn.Conv2d(channels, self.out_channel, 1)
+
+    def forward(self, x, emb):
+        """
+        Apply the block to a Tensor, conditioned on a embedding.
+        :param x: an [N x C x ...] Tensor of features.
+        :param emb: an [N x emb_channels] Tensor of embeddings.
+        :return: an [N x C x ...] Tensor of outputs.
+        """
+        return checkpoint(
+            self._forward, (x, emb), self.parameters(), self.use_checkpoint
+        )
+
+    def _forward(self, x, emb):
+        if self.updown:
+            in_rest, in_conv = self.in_layers[:-1], self.in_layers[-1]
+            h = in_rest(x)
+            h = self.h_upd(h)
+            x = self.x_upd(x)
+            h = in_conv(h)
+        else:
+            h = self.in_layers(x)
+        emb_out = self.emb_layers(emb).type(h.dtype)
+        while len(emb_out.shape) < len(h.shape):
+            emb_out = emb_out[..., None]
+        if self.use_scale_shift_norm:
+            out_norm, out_rest = self.out_layers[0], self.out_layers[1:]
+            scale, shift = torch.chunk(emb_out, 2, dim=1)
+            h = out_norm(h) * (1 + scale) + shift
+            h = out_rest(h)
+        else:
+            h = h + emb_out
+            h = self.out_layers(h)
+        return self.skip_connection(x) + h
+
+
+class AttentionBlock(nn.Module):
+    """
+    An attention block that allows spatial positions to attend to each other.
+    Originally ported from here, but adapted to the N-d case.
+    https://github.com/hojonathanho/diffusion/blob/1e0dceb3b3495bbe19116a5e1b3596cd0706c543/diffusion_tf/models/unet.py#L66.
+    """
+
+    def __init__(
+        self,
+        channels,
+        num_heads=1,
+        num_head_channels=-1,
+        use_checkpoint=False,
+        use_new_attention_order=False,
+    ):
+        super().__init__()
+        self.channels = channels
+        if num_head_channels == -1:
+            self.num_heads = num_heads
+        else:
+            assert (
+                channels % num_head_channels == 0
+            ), f"q,k,v channels {channels} is not divisible by num_head_channels {num_head_channels}"
+            self.num_heads = channels // num_head_channels
+        self.use_checkpoint = use_checkpoint
+        self.norm = normalization(channels)
+        self.qkv = nn.Conv1d(channels, channels * 3, 1)
+        if use_new_attention_order:
+            # split qkv before split heads
+            self.attention = QKVAttention(self.num_heads)
+        else:
+            # split heads before split qkv
+            self.attention = QKVAttentionLegacy(self.num_heads)
+
+        self.proj_out = zero_module(nn.Conv1d(channels, channels, 1))
+
+    def forward(self, x):
+        return checkpoint(self._forward, (x,), self.parameters(), True)
+
+    def _forward(self, x):
+        b, c, *spatial = x.shape
+        x = x.reshape(b, c, -1)
+        qkv = self.qkv(self.norm(x))
+        h = self.attention(qkv)
+        h = self.proj_out(h)
+        return (x + h).reshape(b, c, *spatial)
+
+
+class QKVAttentionLegacy(nn.Module):
+    """
+    A module which performs QKV attention. Matches legacy QKVAttention + input/ouput heads shaping
+    """
+
+    def __init__(self, n_heads):
+        super().__init__()
+        self.n_heads = n_heads
+
+    def forward(self, qkv):
+        """
+        Apply QKV attention.
+        :param qkv: an [N x (H * 3 * C) x T] tensor of Qs, Ks, and Vs.
+        :return: an [N x (H * C) x T] tensor after attention.
+        """
+        bs, width, length = qkv.shape
+        assert width % (3 * self.n_heads) == 0
+        ch = width // (3 * self.n_heads)
+        q, k, v = qkv.reshape(bs * self.n_heads, ch * 3, length).split(ch, dim=1)
+        scale = 1 / math.sqrt(math.sqrt(ch))
+        weight = torch.einsum(
+            "bct,bcs->bts", q * scale, k * scale
+        )  # More stable with f16 than dividing afterwards
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        a = torch.einsum("bts,bcs->bct", weight, v)
+        return a.reshape(bs, -1, length)
+
+    @staticmethod
+    def count_flops(model, _x, y):
+        return count_flops_attn(model, _x, y)
+
+
+class QKVAttention(nn.Module):
+    """
+    A module which performs QKV attention and splits in a different order.
+    """
+
+    def __init__(self, n_heads):
+        super().__init__()
+        self.n_heads = n_heads
+
+    def forward(self, qkv):
+        """
+        Apply QKV attention.
+        :param qkv: an [N x (3 * H * C) x T] tensor of Qs, Ks, and Vs.
+        :return: an [N x (H * C) x T] tensor after attention.
+        """
+        bs, width, length = qkv.shape
+        assert width % (3 * self.n_heads) == 0
+        ch = width // (3 * self.n_heads)
+        q, k, v = qkv.chunk(3, dim=1)
+        scale = 1 / math.sqrt(math.sqrt(ch))
+        weight = torch.einsum(
+            "bct,bcs->bts",
+            (q * scale).view(bs * self.n_heads, ch, length),
+            (k * scale).view(bs * self.n_heads, ch, length),
+        )  # More stable with f16 than dividing afterwards
+        weight = torch.softmax(weight.float(), dim=-1).type(weight.dtype)
+        a = torch.einsum(
+            "bts,bcs->bct", weight, v.reshape(bs * self.n_heads, ch, length)
+        )
+        return a.reshape(bs, -1, length)
+
+    @staticmethod
+    def count_flops(model, _x, y):
+        return count_flops_attn(model, _x, y)
+
+
+class UNet(nn.Module):
+    """
+    The full UNet model with attention and embedding.
+    :param in_channel: channels in the input Tensor, for image colorization : Y_channels + X_channels .
+    :param inner_channel: base channel count for the model.
+    :param out_channel: channels in the output Tensor.
+    :param res_blocks: number of residual blocks per downsample.
+    :param attn_res: a collection of downsample rates at which
+        attention will take place. May be a set, list, or tuple.
+        For example, if this contains 4, then at 4x downsampling, attention
+        will be used.
+    :param dropout: the dropout probability.
+    :param channel_mults: channel multiplier for each level of the UNet.
+    :param conv_resample: if True, use learned convolutions for upsampling and
+        downsampling.
+    :param use_checkpoint: use gradient checkpointing to reduce memory usage.
+    :param num_heads: the number of attention heads in each attention layer.
+    :param num_heads_channels: if specified, ignore num_heads and instead use
+                               a fixed channel width per attention head.
+    :param num_heads_upsample: works with num_heads to set a different number
+                               of heads for upsampling. Deprecated.
+    :param use_scale_shift_norm: use a FiLM-like conditioning mechanism.
+    :param resblock_updown: use residual blocks for up/downsampling.
+    :param use_new_attention_order: use a different attention pattern for potentially
+                                    increased efficiency.
+    """
+
+    def __init__(
+        self,
+        image_size,
+        in_channel,
+        inner_channel,
+        out_channel,
+        res_blocks,
+        attn_res,
+        tanh,
+        dropout=0,
+        channel_mults=(1, 2, 4, 8),
+        conv_resample=True,
+        use_checkpoint=False,
+        use_fp16=False,
+        num_heads=1,
+        num_head_channels=-1,
+        num_heads_upsample=-1,
+        use_scale_shift_norm=True,
+        resblock_updown=True,
+        use_new_attention_order=False,
+    ):
+
+        super().__init__()
+
+        if num_heads_upsample == -1:
+            num_heads_upsample = num_heads
+
+        self.image_size = image_size
+        self.in_channel = in_channel
+        self.inner_channel = inner_channel
+        self.out_channel = out_channel
+        self.res_blocks = res_blocks
+        self.attn_res = attn_res
+        self.dropout = dropout
+        self.channel_mults = channel_mults
+        self.conv_resample = conv_resample
+        self.use_checkpoint = use_checkpoint
+        self.dtype = torch.float16 if use_fp16 else torch.float32
+        self.num_heads = num_heads
+        self.num_head_channels = num_head_channels
+        self.num_heads_upsample = num_heads_upsample
+
+        cond_embed_dim = inner_channel * 4
+        self.cond_embed = nn.Sequential(
+            nn.Linear(inner_channel, cond_embed_dim),
+            SiLU(),
+            nn.Linear(cond_embed_dim, cond_embed_dim),
+        )
+
+        ch = input_ch = int(channel_mults[0] * inner_channel)
+        self.input_blocks = nn.ModuleList(
+            [EmbedSequential(nn.Conv2d(in_channel, ch, 3, padding=1))]
+        )
+        self._feature_size = ch
+        input_block_chans = [ch]
+        ds = 1
+        for level, mult in enumerate(channel_mults):
+            for _ in range(res_blocks):
+                layers = [
+                    ResBlock(
+                        ch,
+                        cond_embed_dim,
+                        dropout,
+                        out_channel=int(mult * inner_channel),
+                        use_checkpoint=use_checkpoint,
+                        use_scale_shift_norm=use_scale_shift_norm,
+                    )
+                ]
+                ch = int(mult * inner_channel)
+                if ds in attn_res:
+                    layers.append(
+                        AttentionBlock(
+                            ch,
+                            use_checkpoint=use_checkpoint,
+                            num_heads=num_heads,
+                            num_head_channels=num_head_channels,
+                            use_new_attention_order=use_new_attention_order,
+                        )
+                    )
+                self.input_blocks.append(EmbedSequential(*layers))
+                self._feature_size += ch
+                input_block_chans.append(ch)
+            if level != len(channel_mults) - 1:
+                out_ch = ch
+                self.input_blocks.append(
+                    EmbedSequential(
+                        ResBlock(
+                            ch,
+                            cond_embed_dim,
+                            dropout,
+                            out_channel=out_ch,
+                            use_checkpoint=use_checkpoint,
+                            use_scale_shift_norm=use_scale_shift_norm,
+                            down=True,
+                        )
+                        if resblock_updown
+                        else Downsample(ch, conv_resample, out_channel=out_ch)
+                    )
+                )
+                ch = out_ch
+                input_block_chans.append(ch)
+                ds *= 2
+                self._feature_size += ch
+
+        self.middle_block = EmbedSequential(
+            ResBlock(
+                ch,
+                cond_embed_dim,
+                dropout,
+                use_checkpoint=use_checkpoint,
+                use_scale_shift_norm=use_scale_shift_norm,
+            ),
+            AttentionBlock(
+                ch,
+                use_checkpoint=use_checkpoint,
+                num_heads=num_heads,
+                num_head_channels=num_head_channels,
+                use_new_attention_order=use_new_attention_order,
+            ),
+            ResBlock(
+                ch,
+                cond_embed_dim,
+                dropout,
+                use_checkpoint=use_checkpoint,
+                use_scale_shift_norm=use_scale_shift_norm,
+            ),
+        )
+        self._feature_size += ch
+
+        self.output_blocks = nn.ModuleList([])
+        for level, mult in list(enumerate(channel_mults))[::-1]:
+            for i in range(res_blocks + 1):
+                ich = input_block_chans.pop()
+                layers = [
+                    ResBlock(
+                        ch + ich,
+                        cond_embed_dim,
+                        dropout,
+                        out_channel=int(inner_channel * mult),
+                        use_checkpoint=use_checkpoint,
+                        use_scale_shift_norm=use_scale_shift_norm,
+                    )
+                ]
+                ch = int(inner_channel * mult)
+                if ds in attn_res:
+                    layers.append(
+                        AttentionBlock(
+                            ch,
+                            use_checkpoint=use_checkpoint,
+                            num_heads=num_heads_upsample,
+                            num_head_channels=num_head_channels,
+                            use_new_attention_order=use_new_attention_order,
+                        )
+                    )
+                if level and i == res_blocks:
+                    out_ch = ch
+                    layers.append(
+                        ResBlock(
+                            ch,
+                            cond_embed_dim,
+                            dropout,
+                            out_channel=out_ch,
+                            use_checkpoint=use_checkpoint,
+                            use_scale_shift_norm=use_scale_shift_norm,
+                            up=True,
+                        )
+                        if resblock_updown
+                        else Upsample(ch, conv_resample, out_channel=out_ch)
+                    )
+                    ds //= 2
+                self.output_blocks.append(EmbedSequential(*layers))
+                self._feature_size += ch
+
+        if tanh:
+            self.out = nn.Sequential(
+                normalization(ch),
+                zero_module(nn.Conv2d(input_ch, out_channel, 3, padding=1)),
+                nn.Tanh(),
+            )
+        else:
+            self.out = nn.Sequential(
+                normalization(ch),
+                SiLU(),
+                zero_module(nn.Conv2d(input_ch, out_channel, 3, padding=1)),
+            )
+
+    def compute_feats(self, input, gammas):
+        if gammas is None:
+            b = input.shape[0]
+            gammas = torch.ones((b,)).to(input.device)
+
+        hs = []
+        gammas = gammas.view(
+            -1,
+        )
+        emb = self.cond_embed(gamma_embedding(gammas, self.inner_channel))
+
+        h = input.type(torch.float32)
+        for module in self.input_blocks:
+            h = module(h, emb)
+            hs.append(h)
+        h = self.middle_block(h, emb)
+
+        outs, feats = h, hs
+        return outs, feats
+
+    def forward(self, input, gammas=None):
+        if gammas is None:
+            b = input.shape[0]
+            gammas = torch.ones((b,)).to(input.device)
+
+        h, hs = self.compute_feats(input, gammas)
+        emb = self.cond_embed(gamma_embedding(gammas, self.inner_channel))
+        for module in self.output_blocks:
+            h = torch.cat([h, hs.pop()], dim=1)
+            h = module(h, emb)
+        h = h.type(input.dtype)
+        return self.out(h)
+
+    def get_feats(self, input, extract_layer_ids):
+        _, hs = self.compute_feats(input, gammas=None)
+
+        feats = []
+
+        for i, feat in enumerate(hs):
+            if i in extract_layer_ids:
+                feats.append(feat)
+
+        return feats
+
+
+if __name__ == "__main__":
+    b, c, h, w = 3, 6, 64, 64
+    timsteps = 100
+    model = UNet(
+        image_size=h,
+        in_channel=c,
+        inner_channel=64,
+        out_channel=3,
+        res_blocks=2,
+        attn_res=[8],
+    )
+    x = torch.randn((b, c, h, w))
+    emb = torch.ones((b,))
+    out = model(x, emb)

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -180,6 +180,7 @@ class BaseOptions:
                 "segformer_attn_conv",
                 "segformer_conv",
                 "ittr",
+                "unet_mha",
             ],
             help="specify generator architecture",
         )
@@ -246,6 +247,9 @@ class BaseOptions:
             ],
             help="specify multimodal latent vector encoder",
         )
+
+        parser.add_argument("--G_unet_mha_inner_channel", default=64, type=int)
+        parser.add_argument("--G_unet_mha_num_head_channels", default=32, type=int)
 
         # discriminator
         parser.add_argument(

--- a/tests/test_run_semantic_mask.py
+++ b/tests/test_run_semantic_mask.py
@@ -33,6 +33,9 @@ json_like_dict = {
     "train_mask_compute_miou": True,
     "train_mask_miou_every": 1,
     "train_semantic_mask": True,
+    "G_unet_mha_inner_channel": 32,
+    "G_unet_mha_num_head_channels": 16,
+    "G_nblocks": 1,
 }
 
 models_semantic_mask = [
@@ -40,7 +43,7 @@ models_semantic_mask = [
     "cycle_gan",
 ]
 
-G_netG = ["mobile_resnet_attn", "segformer_attn_conv", "ittr"]
+G_netG = ["mobile_resnet_attn", "segformer_attn_conv", "ittr", "unet_mha"]
 
 D_proj_network_type = ["efficientnet", "vitsmall"]
 


### PR DESCRIPTION
Unet generator from https://github.com/Janspiry/Palette-Image-to-Image-Diffusion-Models.

New options : 
- `G_unet_mha_inner_channel`: to specify inner channel size
- `G_unet_mha_num_head_channels` : to specify number of channels per attention head

Usage:
```
python3 train.py --G_netG unet_mha --G_nblocks 2 --G_unet_mha_inner_channel 64 --G_unet_mha_num_head_channels 32
```