### PR TITLE
chore: split networks.py

### DIFF
--- a/models/base_gan_model.py
+++ b/models/base_gan_model.py
@@ -3,7 +3,7 @@ import copy
 import torch
 from collections import OrderedDict
 from abc import abstractmethod
-from . import networks
+from . import gan_networks
 from .modules.utils import get_scheduler
 from torchviz import make_dot
 from .base_model import BaseModel

--- a/models/base_model.py
+++ b/models/base_model.py
@@ -3,7 +3,7 @@ import copy
 import torch
 from collections import OrderedDict
 from abc import ABC, abstractmethod
-from . import networks
+from . import gan_networks, semantic_networks
 from .modules.utils import get_scheduler
 from torchviz import make_dot
 
@@ -19,6 +19,7 @@ from .modules.fid.pytorch_fid.fid_score import (
 from util.util import save_image, tensor2im
 import numpy as np
 from util.diff_aug import DiffAugment
+from . import base_networks
 
 # for D accuracy
 from util.image_pool import ImagePool
@@ -96,7 +97,7 @@ class BaseModel(ABC):
             self.transform = get_transform(opt, grayscale=(opt.model_input_nc == 1))
             dims = 2048
             batch = 1
-            self.netFid = networks.define_inception(self.gpu_ids[0], dims)
+            self.netFid = base_networks.define_inception(self.gpu_ids[0], dims)
 
             pathA = opt.dataroot + "/trainA"
             path_sv_A = os.path.join(
@@ -249,7 +250,7 @@ class BaseModel(ABC):
 
         # define network CLS
         if self.isTrain:
-            self.netCLS = networks.define_C(**vars(opt))
+            self.netCLS = semantic_networks.define_C(**vars(opt))
 
             self.model_names += ["CLS"]
 
@@ -316,13 +317,13 @@ class BaseModel(ABC):
             if self.opt.train_mask_disjoint_f_s:
                 self.opt.train_f_s_B = True
 
-                self.netf_s_A = networks.define_f(**vars(opt))
+                self.netf_s_A = semantic_networks.define_f(**vars(opt))
                 networks_f_s.append("f_s_A")
 
-                self.netf_s_B = networks.define_f(**vars(opt))
+                self.netf_s_B = semantic_networks.define_f(**vars(opt))
                 networks_f_s.append("f_s_B")
             else:
-                self.netf_s = networks.define_f(**vars(opt))
+                self.netf_s = semantic_networks.define_f(**vars(opt))
                 networks_f_s.append("f_s")
 
             self.model_names += networks_f_s

--- a/models/base_networks.py
+++ b/models/base_networks.py
@@ -1,0 +1,7 @@
+from .modules.fid.pytorch_fid.inception import InceptionV3
+
+
+def define_inception(device, dims):
+    block_idx = InceptionV3.BLOCK_INDEX_BY_DIM[dims]
+    model = InceptionV3([block_idx]).to(device)
+    return model

--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from .base_gan_model import BaseGanModel
-from . import networks
+from . import gan_networks
 
 from .modules import loss
 from .patchnce import PatchNCELoss
@@ -181,17 +181,17 @@ class CUTModel(BaseGanModel):
         if self.opt.model_multimodal:
             tmp_model_input_nc = self.opt.model_input_nc
             self.opt.model_input_nc += self.opt.train_mm_nz
-        self.netG_A = networks.define_G(**vars(opt))
+        self.netG_A = gan_networks.define_G(**vars(opt))
         if self.opt.model_multimodal:
             self.opt.model_input_nc = tmp_model_input_nc
-        self.netF = networks.define_F(**vars(opt))
+        self.netF = gan_networks.define_F(**vars(opt))
         self.netF.set_device(self.device)
         if self.opt.model_multimodal:
-            self.netE = networks.define_E(**vars(opt))
+            self.netE = gan_networks.define_E(**vars(opt))
 
         if self.isTrain:
             # Discriminator(s)
-            self.netDs = networks.define_D(**vars(opt))
+            self.netDs = gan_networks.define_D(**vars(opt))
 
             self.discriminators_names = [
                 "D_B_" + D_name for D_name in self.netDs.keys()

--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -3,7 +3,7 @@ import torch
 import torch.nn.functional as F
 
 from .base_gan_model import BaseGanModel
-from . import networks
+from . import gan_networks
 
 from .modules import loss
 
@@ -119,15 +119,15 @@ class CycleGanModel(BaseGanModel):
 
         # Generators
 
-        self.netG_A = networks.define_G(**vars(opt))
-        self.netG_B = networks.define_G(**vars(opt))
+        self.netG_A = gan_networks.define_G(**vars(opt))
+        self.netG_B = gan_networks.define_G(**vars(opt))
 
         # Discriminators
 
         if self.isTrain:
 
-            self.netD_As = networks.define_D(**vars(opt))
-            self.netD_Bs = networks.define_D(**vars(opt))
+            self.netD_As = gan_networks.define_D(**vars(opt))
+            self.netD_Bs = gan_networks.define_D(**vars(opt))
 
             discriminators_names_A = ["D_A_" + D_name for D_name in self.netD_As.keys()]
             discriminators_names_B = ["D_B_" + D_name for D_name in self.netD_Bs.keys()]

--- a/models/re_cut_semantic_mask_model.py
+++ b/models/re_cut_semantic_mask_model.py
@@ -1,7 +1,7 @@
 import torch
 import itertools
 from .cut_semantic_mask_model import CUTSemanticMaskModel
-from . import networks
+from . import gan_networks
 from torch.autograd import Variable
 import numpy as np
 import torch.nn.functional as F

--- a/models/re_cycle_gan_semantic_mask_model.py
+++ b/models/re_cycle_gan_semantic_mask_model.py
@@ -1,7 +1,7 @@
 import torch
 import itertools
 from .cycle_gan_semantic_mask_model import CycleGANSemanticMaskModel
-from . import networks
+from . import gan_networks
 from torch.autograd import Variable
 import numpy as np
 import torch.nn.functional as F

--- a/models/segmentation_model.py
+++ b/models/segmentation_model.py
@@ -2,7 +2,7 @@ import torch
 import itertools
 from util.image_pool import ImagePool
 from .base_model import BaseModel
-from . import networks
+from . import gan_networks
 from torch.autograd import Variable
 import numpy as np
 import torch.nn.functional as F

--- a/models/semantic_networks.py
+++ b/models/semantic_networks.py
@@ -1,0 +1,96 @@
+import os
+
+from .modules.classifiers import (
+    Classifier,
+    VGG16_FCN8s,
+    torch_model,
+    TORCH_MODEL_CLASSES,
+)
+from .modules.UNet_classification import UNet
+from .modules.segformer.segformer_generator import Segformer
+
+from .modules.utils import init_net
+
+
+def define_C(
+    model_output_nc,
+    f_s_nf,
+    data_crop_size,
+    f_s_semantic_nclasses,
+    train_sem_cls_template,
+    model_init_type,
+    model_init_gain,
+    train_sem_cls_pretrained,
+    **unused_options
+):
+    img_size = data_crop_size
+    if train_sem_cls_template == "basic":
+        netC = Classifier(model_output_nc, f_s_nf, f_s_semantic_nclasses, img_size)
+    else:
+        netC = torch_model(
+            model_output_nc,
+            f_s_nf,
+            f_s_semantic_nclasses,
+            img_size,
+            train_sem_cls_template,
+            train_sem_cls_pretrained,
+        )
+    return init_net(netC, model_init_type, model_init_gain)
+
+
+def define_f(
+    f_s_net,
+    model_input_nc,
+    f_s_semantic_nclasses,
+    model_init_type,
+    model_init_gain,
+    f_s_config_segformer,
+    f_s_weight_segformer,
+    jg_dir,
+    data_crop_size,
+    **unused_options
+):
+    if f_s_net == "vgg":
+        net = VGG16_FCN8s(
+            f_s_semantic_nclasses,
+            pretrained=False,
+            weights_init=None,
+            output_last_ft=False,
+        )
+    elif f_s_net == "unet":
+        net = UNet(classes=f_s_semantic_nclasses, input_nc=model_input_nc)
+    elif f_s_net == "segformer":
+        net = Segformer(
+            jg_dir,
+            f_s_config_segformer,
+            model_input_nc,
+            img_size=data_crop_size,
+            num_classes=f_s_semantic_nclasses,
+            final_conv=False,
+        )
+        if f_s_weight_segformer:
+            weight_path = os.path.join(jg_dir, f_s_weight_segformer)
+            if not os.path.exists(weight_path):
+                print("Downloading pretrained segformer weights for f_s.")
+                download_segformer_weight(weight_path)
+
+            weights = get_weights(weight_path)
+
+            try:
+                net.net.load_state_dict(weights, strict=False)
+            except:
+                print(
+                    "f_s pretrained segformer decode_head size may have the wrong number of classes, fixing"
+                )
+                pretrained_dict = {k: v for k, v in weights.items() if k in weights}
+                decode_head_keys = []
+                for k in pretrained_dict.keys():
+                    if "decode_head" in k:
+                        decode_head_keys.append(k)
+                for k in decode_head_keys:
+                    del weights[k]
+
+                net.net.load_state_dict(weights, strict=False)
+        return net
+
+    return init_net(net, model_init_type, model_init_gain)

--- a/models/template_model.py
+++ b/models/template_model.py
@@ -17,7 +17,7 @@ You need to implement the following functions:
 """
 import torch
 from .base_model import BaseModel
-from . import networks
+from . import gan_networks
 from .modules import loss
 
 

--- a/models/test_model.py
+++ b/models/test_model.py
@@ -1,5 +1,5 @@
 from .base_model import BaseModel
-from . import networks
+from . import gan_networks
 
 
 class TestModel(BaseModel):


### PR DESCRIPTION
This PR split `networks.py` into three specific files : `networks.py`, `gan_networks.py` and `semantic_networks.py`. 

For now, export doesn't work.