### PR TITLE
fix: cls_class_weights default to []

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -445,7 +445,7 @@ class BaseOptions:
         )
         parser.add_argument(
             "--cls_class_weights",
-            default=None,
+            default=[],
             nargs="*",
             type=int,
             help="class weights for imbalanced semantic classes",


### PR DESCRIPTION
`cls_class_weights` default to `[]`