### PR TITLE
fix: gan_networks import for inference

### DIFF
--- a/scripts/gen_single_image.py
+++ b/scripts/gen_single_image.py
@@ -3,7 +3,7 @@ import os
 import json
 
 sys.path.append("../")
-from models import networks, networks_diffusion
+from models import gan_networks
 from options.train_options import TrainOptions
 import cv2
 import torch
@@ -30,7 +30,7 @@ def load_model(modelpath, model_in_file, device):
         opt.model_input_nc += opt.train_mm_nz
     opt.jg_dir = "../"
 
-    model = networks_diffusion.define_G(**vars(opt))
+    model = gan_networks.define_G(**vars(opt))
     model.eval()
     model.load_state_dict(torch.load(modelpath + "/" + model_in_file))
 


### PR DESCRIPTION
This PR fixes the import of `gan_networks` in `gen_single_image.py`.

