### PR TITLE
fix: lambda for GAN losses

### DIFF
--- a/models/base_gan_model.py
+++ b/models/base_gan_model.py
@@ -39,6 +39,18 @@ class BaseGanModel(BaseModel):
         -- <modify_commandline_options>:    (optionally) add model-specific options and set default options.
     """
 
+    def modify_commandline_options(parser, is_train=True):
+        """Configures options specific for CUT model"""
+
+        parser.add_argument(
+            "--alg_gan_lambda",
+            type=float,
+            default=1.0,
+            help="weight for GAN loss：GAN(G(X))",
+        )
+
+        return parser
+
     def __init__(self, opt, rank):
         """Initialize the BaseModel class.
 
@@ -455,7 +467,7 @@ class BaseGanModel(BaseModel):
                     fake_name = None
                     real_name = None
 
-                loss_value = self.compute_G_loss_GAN_generic(
+                loss_value = self.opt.alg_gan_lambda * self.compute_G_loss_GAN_generic(
                     netD,
                     domain,
                     loss,

--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -30,12 +30,7 @@ class CUTModel(BaseGanModel):
     @staticmethod
     def modify_commandline_options(parser, is_train=True):
         """Configures options specific for CUT model"""
-        parser.add_argument(
-            "--alg_cut_lambda_GAN",
-            type=float,
-            default=1.0,
-            help="weight for GAN loss：GAN(G(X))",
-        )
+        parser = BaseGanModel.modify_commandline_options(parser, is_train=is_train)
         parser.add_argument(
             "--alg_cut_lambda_NCE",
             type=float,

--- a/models/cycle_gan_model.py
+++ b/models/cycle_gan_model.py
@@ -30,6 +30,7 @@ class CycleGanModel(BaseGanModel):
     @staticmethod
     def modify_commandline_options(parser, is_train=True):
         """Configures options specific for cyclegan model"""
+        parser = BaseGanModel.modify_commandline_options(parser, is_train=is_train)
         parser.set_defaults(G_dropout=False)  # default CycleGAN did not use dropout
         if is_train:
             parser.add_argument(

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -29,6 +29,7 @@ class BaseOptions:
             "alg": {
                 "title": "Algorithm-specific",
                 "properties": {
+                    "gan": {"title": "GAN model"},
                     "cut": {"title": "CUT model"},
                     "cyclegan": {"title": "CycleGAN model"},
                     "re": {"title": "ReCUT / ReCycleGAN"},


### PR DESCRIPTION
`alg_cut_lambda_GAN` is now replaced by `alg_gan_lambda` and can be used with both cut and cyclegan models