### PR TITLE
chore: reduce memory of unet_mha unit tests

### DIFF
--- a/models/gan_networks.py
+++ b/models/gan_networks.py
@@ -65,6 +65,7 @@ def define_G(
     G_stylegan2_num_downsampling,
     G_backward_compatibility_twice_resnet_blocks,
     G_unet_mha_num_head_channels,
+    G_unet_mha_channel_mults,
     **unused_options
 ):
     """Create a generator
@@ -219,7 +220,7 @@ def define_G(
             out_channel=model_output_nc,
             res_blocks=G_nblocks,  # 2 in palette repo
             attn_res=[16],  # e.g.
-            channel_mults=(1, 2, 4, 8),  # e.g.
+            channel_mults=G_unet_mha_channel_mults,  # e.g. (1, 2, 4, 8)
             num_head_channels=G_unet_mha_num_head_channels,  # e.g. 32 in palette repo
             tanh=True,
             n_timestep_train=0,  # unused

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -261,6 +261,14 @@ class BaseOptions:
             help="Number of timesteps used for UNET mha inference (test time).",
         )
 
+        parser.add_argument(
+            "--G_unet_mha_channel_mults",
+            default=[1, 2, 4, 8],
+            nargs="*",
+            type=int,
+            help="channel multiplier for each level of the UNET mha",
+        )
+
         # discriminator
         parser.add_argument(
             "--D_ndf",

--- a/tests/test_run_diffusion.py
+++ b/tests/test_run_diffusion.py
@@ -23,6 +23,7 @@ json_like_dict = {
     "dataaug_no_rotate": True,
     "G_unet_mha_inner_channel": 32,
     "G_unet_mha_num_head_channels": 16,
+    "G_unet_mha_channel_mults": [1, 2],
     "G_nblocks": 1,
     "G_padding_type": "reflect",
     "data_online_creation_rand_mask_A": True,
@@ -30,12 +31,7 @@ json_like_dict = {
 
 
 models_diffusion = ["palette"]
-
 G_netG = ["unet_mha"]
-
-D_proj_network_type = ["efficientnet", "vitsmall"]
-
-f_s_net = ["unet", "segformer"]
 
 
 def test_semantic_mask(dataroot):

--- a/tests/test_run_semantic_mask.py
+++ b/tests/test_run_semantic_mask.py
@@ -35,6 +35,7 @@ json_like_dict = {
     "train_semantic_mask": True,
     "G_unet_mha_inner_channel": 32,
     "G_unet_mha_num_head_channels": 16,
+    "G_unet_mha_channel_mults": [1, 2],
     "G_nblocks": 1,
 }
 


### PR DESCRIPTION
Introduces new option `--G_unet_mha_channel_mults` with value `1 2 4 8` as default.