### PR TITLE
feat(aug): configurable online mask delta augmentation by x and y axis

### DIFF
--- a/data/online_creation.py
+++ b/data/online_creation.py
@@ -87,13 +87,18 @@ def crop_image(
             xmax = math.floor(int(bbox[3]) * ratio_x)
             ymax = math.floor(int(bbox[4]) * ratio_y)
 
-            if (
-                mask_delta > 0
-            ):  # increase mask box so that it can fit the reconstructed object (for semantic loss)
-                ymin -= mask_delta
-                ymax += mask_delta
-                xmin -= mask_delta
-                xmax += mask_delta
+            if len(mask_delta) == 1:
+                mask_delta_x = mask_delta[0]
+                mask_delta_y = mask_delta[0]
+            elif len(mask_delta) == 2:
+                mask_delta_x = mask_delta[0]
+                mask_delta_y = mask_delta[1]
+
+            if mask_delta_x > 0 or mask_delta_y > 0:
+                ymin -= mask_delta_y
+                ymax += mask_delta_y
+                xmin -= mask_delta_x
+                xmax += mask_delta_x
 
             if mask_square:
                 sdiff = (xmax - xmin) - (ymax - ymin)

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -587,8 +587,9 @@ class BaseOptions:
         parser.add_argument(
             "--data_online_creation_mask_delta_A",
             type=int,
-            default=0,
-            help="mask offset to allow generation of a bigger object in domain B (for semantic loss) for domain A",
+            default=[0],
+            nargs="*",
+            help="mask offset to allow generation of a bigger object in domain B (for semantic loss) for domain A, format : width (x) height (y) or only one size if square",
         )
         parser.add_argument(
             "--data_online_creation_mask_square_A",
@@ -629,8 +630,9 @@ class BaseOptions:
         parser.add_argument(
             "--data_online_creation_mask_delta_B",
             type=int,
-            default=0,
-            help="mask offset to allow genaration of a bigger object in domain B (for semantic loss) for domain B",
+            default=[0],
+            nargs="*",
+            help="mask offset to allow genaration of a bigger object in domain B (for semantic loss) for domain B, format : width (y) height (x) or only one size if square",
         )
         parser.add_argument(
             "--data_online_creation_mask_square_B",


### PR DESCRIPTION
This PR changes the following options:
- `--data_online_creation_mask_delta_A` and `--data_online_creation_mask_delta_B`

Mask delta used to be the same for width and height, now we can use different values for both axis.

Usage:
```
python3 train.py --data_online_creation_mask_delta_A 10 --data_online_creation_mask_delta_B 10 15
```
