### PR TITLE
chore: display nets architecture on visdom

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -677,8 +677,6 @@ class BaseModel(ABC):
                 else opt.train_epoch
             )
             self.load_networks(load_suffix)
-        if self.rank == 0:
-            self.print_networks(opt.output_verbose)
 
     def parallelize(self, rank):
         for name in self.model_names:
@@ -879,26 +877,12 @@ class BaseModel(ABC):
                 else:
                     net.load_state_dict(state_dict)
 
-    def print_networks(self, verbose):
-        """Print the total number of parameters in the network and (if verbose) network architecture
-
-        Parameters:
-            verbose (bool) -- if verbose: print the network architecture
-        """
-        print("---------- Networks initialized -------------")
+    def get_nets(self):
+        return_nets = {}
         for name in self.model_names:
             if isinstance(name, str):
-                net = getattr(self, "net" + name)
-                num_params = 0
-                for param in net.parameters():
-                    num_params += param.numel()
-                if verbose:
-                    print(net)
-                print(
-                    "[Network %s] Total number of parameters : %.3f M"
-                    % (name, num_params / 1e6)
-                )
-        print("-----------------------------------------------")
+                return_nets[name] = getattr(self, "net" + name)
+        return return_nets
 
     def set_requires_grad(self, nets, requires_grad=False):
         """Set requires_grad=False for all the networks to avoid unnecessary computations

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ wget
 tqdm
 git+https://github.com/nupurkmr9/vision-aided-gan.git
 einops
+torchinfo

--- a/train.py
+++ b/train.py
@@ -105,6 +105,9 @@ def train_gpu(rank, world_size, opt, dataset, dataset_temporal):
         visualizer = Visualizer(
             opt
         )  # create a visualizer that display/save images and plots
+
+        visualizer.print_networks(nets=model.get_nets(), verbose=opt.output_verbose)
+
     total_iters = 0  # the total number of training iterations
 
     if rank == 0 and opt.train_compute_fid_val:


### PR DESCRIPTION
This PR displays networks architectures using torchinfo.

Displayed when `output_verbose` is enanled.