### PR TITLE
fix: multimodal GAN requires retain_graph for now

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -1056,7 +1056,11 @@ class BaseModel(ABC):
                     )
                 else:
                     ll = getattr(self, loss) / self.opt.train_iter_size
-                ll.backward(retain_graph=False)
+                if self.opt.model_multimodal:
+                    retain_graph = True
+                else:
+                    retain_graph = False
+                ll.backward(retain_graph=retain_graph)
 
             loss_names = []
 


### PR DESCRIPTION
Note: this may require a fix in the future, to remove retain_graph requirement.