### PR TITLE
feat: depth prediction and depth discriminator

### DIFF
--- a/models/cut_model.py
+++ b/models/cut_model.py
@@ -183,10 +183,15 @@ class CUTModel(BaseGanModel):
             self.visual_names.append(visual_names_temporal_real_B)
             self.visual_names.append(visual_names_temporal_fake_B)
 
+        if any("depth" in D_name for D_name in self.opt.D_netDs):
+            self.visual_names.append(["real_depth_B", "fake_depth_B"])
+
         if self.isTrain:
             self.model_names = ["G_A", "F"]
             if self.opt.model_multimodal:
                 self.model_names.append("E")
+            if self.use_depth:
+                self.model_names.append("freeze_depth")
 
             self.model_names_export = ["G_A"]
 
@@ -475,6 +480,9 @@ class CUTModel(BaseGanModel):
 
         if self.opt.data_online_context_pixels > 0:
             self.compute_fake_with_context(fake_name="fake_B", real_name="real_A")
+
+        if self.use_depth:
+            self.compute_fake_real_with_depth(fake_name="fake_B", real_name="real_B")
 
         if self.opt.alg_cut_nce_idt:
             self.idt_B = self.fake[self.real_A.size(0) :]

--- a/models/modules/utils.py
+++ b/models/modules/utils.py
@@ -1,5 +1,6 @@
 from torch import nn
 import torch
+from torchvision import transforms
 from torchvision.models import vgg
 import numpy as np
 from torch.nn import init
@@ -227,3 +228,24 @@ def download_segformer_weight(path):
             "There is no pretrained weight to download for %s, you need to provide a path to segformer weights."
             % model_name
         )
+
+
+def download_midas_weight(model_type="DPT_Large"):
+    midas = torch.hub.load("intel-isl/MiDaS", model_type)
+    midas.requires_grad_(False)
+    midas.eval()
+    return midas
+
+
+def predict_depth(img, midas, model_type):
+    # img must be RGB
+    input_size = 384
+    if model_type == "MiDas_small":
+        input_size = 256
+    transform = transforms.Compose(
+        [
+            transforms.Resize(384),
+        ]
+    )
+    prediction = midas(transform(img))
+    return prediction

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -151,6 +151,19 @@ class BaseOptions:
             help="multimodal model with random latent input vector",
         )
 
+        # depth network
+        parser.add_argument(
+            "--model_depth_network",
+            type=str,
+            default="DPT_Large",
+            choices=[
+                "DPT_Large",
+                "DPT_Hybrid",  # MiDaS v3 - Hybrid    (medium accuracy, medium inference speed)
+                "MiDaS_small",
+            ],  # MiDaS v2.1 - Small   (lowest accuracy, highest inference speed)
+            help="specify depth prediction network architecture",
+        )
+
         # generator
         parser.add_argument(
             "--G_ngf",
@@ -290,6 +303,7 @@ class BaseOptions:
                 "projected_d",
                 "temporal",
                 "vision_aided",
+                "depth",
             ]
             + list(TORCH_MODEL_CLASSES.keys()),
             help="specify discriminator architecture, D_n_layers allows you to specify the layers in the discriminator. NB: duplicated arguments will be ignored.",
@@ -299,7 +313,7 @@ class BaseOptions:
             "--D_vision_aided_backbones",
             type=str,
             default="clip+dino+swin",
-            help="specify discriminators architectures, they are frozen then output are combined and fitted with a linear network on top, choose from dino, clip, swin, det_coco, seg_ade and combine them with +",
+            help="specify vision aided discriminators architectures, they are frozen then output are combined and fitted with a linear network on top, choose from dino, clip, swin, det_coco, seg_ade and combine them with +",
         )
         parser.add_argument(
             "--D_n_layers", type=int, default=3, help="only used if netD==n_layers"

--- a/tests/test_run_nosemantic.py
+++ b/tests/test_run_nosemantic.py
@@ -19,12 +19,15 @@ json_like_dict = {
     "train_n_epochs": 1,
     "train_n_epochs_decay": 0,
     "data_max_dataset_size": 10,
+    "model_depth_network": "MiDaS_small",
 }
 
 models_nosemantic = [
     "cut",
     "cycle_gan",
 ]
+
+D_netDs = [["projected_d", "basic"], ["projected_d", "basic", "depth"]]
 
 
 def test_nosemantic(dataroot):
@@ -33,5 +36,9 @@ def test_nosemantic(dataroot):
     for model in models_nosemantic:
         json_like_dict["model_type"] = model
         json_like_dict["name"] += "_" + model
-        opt = TrainOptions().parse_json(json_like_dict.copy())
-        train.launch_training(opt)
+        for Dtype in D_netDs:
+            if model == "cycle_gan" and "depth" in Dtype:
+                continue  # skip
+            json_like_dict["D_netDs"] = Dtype
+            opt = TrainOptions().parse_json(json_like_dict.copy())
+            train.launch_training(opt)


### PR DESCRIPTION
This PR adds depth prediction and a dedicated discriminator (`--D_netDs depth`). 
Choices of depth network with `--model_depth_network`, among `["DPT_Large", "DPT_Hybrid", "MiDaS_small"]`.

Notes: 
- depth network is handled outside of the discriminator (whereas it could have been handled inside it, similarly to projected D). This allows working on having multiple discriminator architectures over depth predictions, to be updated.
~- tensor2img is hacked for the depth image to render properly, will fix.~ / fixed
