### PR TITLE
fix: remove eval mode for export

### DIFF
--- a/models/base_model.py
+++ b/models/base_model.py
@@ -756,8 +756,6 @@ class BaseModel(ABC):
                     if not "ittr" in self.opt.G_netG:
                         export_path_onnx = save_path.replace(".pth", ".onnx")
 
-                        net.eval()
-
                         export_onnx(
                             self.opt,
                             cuda=False,  # onnx export is made on cpu


### PR DESCRIPTION
This PR removes eval model when exporting models. It used to fail in multi gpu training.