### PR TITLE
feat: previous frame as y cond in palette

### DIFF
--- a/data/online_creation.py
+++ b/data/online_creation.py
@@ -291,9 +291,10 @@ def fill_mask_with_color(img, mask, colors):
             color = (0, 0, 0)
         mask = torch.where(mask == cls, 1.0, 0.0)
         dims = img.shape
+
         assert (
             len(color) == dims[-3]
-        ), "fill_mask_with_color: number of channels do not match"
+        ), "fill_mask_with_color: number of channels does not match"
         color = torch.tensor(color).repeat_interleave(dims[-2] * dims[-1]).reshape(dims)
         img = img * (1 - mask) + color * mask
 

--- a/data/self_supervised_temporal_dataset.py
+++ b/data/self_supervised_temporal_dataset.py
@@ -1,0 +1,71 @@
+import torch
+
+
+from data.temporal_dataset import TemporalDataset
+from data.online_creation import fill_mask_with_random, fill_mask_with_color
+
+
+class SelfSupervisedTemporalDataset(TemporalDataset):
+    """
+    This dataset class can create datasets with mask labels from one domain.
+    """
+
+    def __init__(self, opt):
+        """Initialize this dataset class.
+
+        Parameters:
+            opt (Option class) -- stores all the experiment flags; needs to be a subclass of BaseOptions
+        """
+        super().__init__(opt)
+
+    def get_img(
+        self,
+        A_img_path,
+        A_label_mask_path,
+        A_label_cls,
+        B_img_path=None,
+        B_label_mask_path=None,
+        B_label_cls=None,
+        index=None,
+    ):
+        result = super().get_img(
+            A_img_path,
+            A_label_mask_path,
+            A_label_cls,
+            B_img_path,
+            B_label_mask_path,
+            B_label_cls,
+            index,
+        )
+
+        try:
+            A_img_list = [result["A"][0]]
+            if self.opt.data_online_creation_rand_mask_A:
+                A_img = fill_mask_with_random(
+                    result["A"][1], result["A_label_mask"][1], -1
+                )
+            elif self.opt.data_online_creation_color_mask_A:
+                A_img = fill_mask_with_color(
+                    result["A"][1], result["A_label_mask"][1], {}
+                )
+            else:
+                raise Exception(
+                    "self supervised dataset: no self supervised method specified"
+                )
+
+            A_img_list.append(A_img)
+
+            A_img_list = torch.stack(A_img_list)
+
+            result.update(
+                {
+                    "A": A_img_list,
+                    "B": result["A"],
+                    "B_label_mask": result["A_label_mask"].clone(),
+                }
+            )
+        except Exception as e:
+            print(e, "self supervised data loading")
+            return None
+
+        return result

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -532,6 +532,9 @@ class BaseOptions:
                 "self_supervised_labeled_mask_online",
                 "unaligned_labeled_mask_cls_online",
                 "aligned",
+                "nuplet_unaligned_labeled_mask",
+                "temporal",
+                "self_supervised_temporal",
             ],
             help="chooses how datasets are loaded.",
         )


### PR DESCRIPTION
Option to use previous frame as y cond during palette training.

Usage:

```
python train.py --D_temporal_number_frames 2 --alg_palette_cond_image_creation previous_frame --data_dataset_mode self_supervised_temporal
```