### PR TITLE
feat: fixed bbox size for online creation

### DIFF
--- a/data/temporal_dataset.py
+++ b/data/temporal_dataset.py
@@ -123,6 +123,7 @@ class TemporalDataset(BaseDataset):
                         cur_A_img_path,
                         cur_A_label_path,
                         mask_delta=self.opt.data_online_creation_mask_delta_A,
+                        mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
                         crop_delta=self.opt.data_online_creation_crop_delta_A,
                         mask_square=self.opt.data_online_creation_mask_square_A,
                         crop_dim=self.opt.data_online_creation_crop_size_A,
@@ -130,11 +131,13 @@ class TemporalDataset(BaseDataset):
                         context_pixels=self.opt.data_online_context_pixels,
                         load_size=self.opt.data_online_creation_load_size_A,
                         get_crop_coordinates=True,
+                        fixed_mask_size=self.opt.data_online_fixed_mask_size,
                     )
                 cur_A_img, cur_A_label = crop_image(
                     cur_A_img_path,
                     cur_A_label_path,
                     mask_delta=self.opt.data_online_creation_mask_delta_A,
+                    mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
                     crop_delta=self.opt.data_online_creation_crop_delta_A,
                     mask_square=self.opt.data_online_creation_mask_square_A,
                     crop_dim=self.opt.data_online_creation_crop_size_A,
@@ -142,6 +145,7 @@ class TemporalDataset(BaseDataset):
                     context_pixels=self.opt.data_online_context_pixels,
                     load_size=self.opt.data_online_creation_load_size_A,
                     crop_coordinates=crop_coordinates,
+                    fixed_mask_size=self.opt.data_online_fixed_mask_size,
                 )
 
             except Exception as e:
@@ -209,6 +213,7 @@ class TemporalDataset(BaseDataset):
                         cur_B_img_path,
                         cur_B_label_path,
                         mask_delta=self.opt.data_online_creation_mask_delta_B,
+                        mask_random_offset=self.opt.data_online_creation_mask_random_offset_B,
                         crop_delta=self.opt.data_online_creation_crop_delta_B,
                         mask_square=self.opt.data_online_creation_mask_square_B,
                         crop_dim=self.opt.data_online_creation_crop_size_B,
@@ -216,6 +221,7 @@ class TemporalDataset(BaseDataset):
                         context_pixels=self.opt.data_online_context_pixels,
                         load_size=self.opt.data_online_creation_load_size_B,
                         crop_coordinates=crop_coordinates,
+                        fixed_mask_size=self.opt.data_online_fixed_mask_size,
                     )
 
                 except Exception as e:

--- a/data/unaligned_labeled_mask_online_dataset.py
+++ b/data/unaligned_labeled_mask_online_dataset.py
@@ -162,6 +162,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                 self.A_img_paths,
                 self.A_label_mask_paths,
                 mask_delta=self.opt.data_online_creation_mask_delta_A,
+                mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
                 crop_delta=self.opt.data_online_creation_crop_delta_A,
                 mask_square=self.opt.data_online_creation_mask_square_A,
                 crop_dim=self.opt.data_online_creation_crop_size_A,
@@ -183,6 +184,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                     self.A_img_paths_val,
                     self.A_label_mask_paths_val,
                     mask_delta=self.opt.data_online_creation_mask_delta_A,
+                    mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
                     crop_delta=self.opt.data_online_creation_crop_delta_A,
                     mask_square=self.opt.data_online_creation_mask_square_A,
                     crop_dim=self.opt.data_online_creation_crop_size_A,
@@ -204,6 +206,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                     self.B_img_paths,
                     self.B_label_mask_paths,
                     mask_delta=self.opt.data_online_creation_mask_delta_B,
+                    mask_random_offset=self.opt.data_online_creation_mask_random_offset_B,
                     crop_delta=self.opt.data_online_creation_crop_delta_B,
                     mask_square=self.opt.data_online_creation_mask_square_B,
                     crop_dim=self.opt.data_online_creation_crop_size_B,
@@ -224,6 +227,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                         self.B_img_paths_val,
                         self.B_label_mask_paths_val,
                         mask_delta=self.opt.data_online_creation_mask_delta_B,
+                        mask_random_offset=self.opt.data_online_creation_mask_random_offset_B,
                         crop_delta=self.opt.data_online_creation_crop_delta_B,
                         mask_square=self.opt.data_online_creation_mask_square_B,
                         crop_dim=self.opt.data_online_creation_crop_size_B,
@@ -252,11 +256,13 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
         index=None,
     ):
         # Domain A
+
         try:
             A_img, A_label_mask = crop_image(
                 A_img_path,
                 A_label_mask_path,
                 mask_delta=self.opt.data_online_creation_mask_delta_A,
+                mask_random_offset=self.opt.data_online_creation_mask_random_offset_A,
                 crop_delta=self.opt.data_online_creation_crop_delta_A,
                 mask_square=self.opt.data_online_creation_mask_square_A,
                 crop_dim=self.opt.data_online_creation_crop_size_A,
@@ -264,6 +270,7 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                 context_pixels=self.opt.data_online_context_pixels,
                 load_size=self.opt.data_online_creation_load_size_A,
                 select_cat=self.opt.data_online_select_category,
+                fixed_mask_size=self.opt.data_online_fixed_mask_size,
             )
 
         except Exception as e:
@@ -291,12 +298,14 @@ class UnalignedLabeledMaskOnlineDataset(BaseDataset):
                         B_img_path,
                         B_label_mask_path,
                         mask_delta=self.opt.data_online_creation_mask_delta_B,
+                        mask_random_offset=self.opt.data_online_creation_mask_random_offset_B,
                         crop_delta=self.opt.data_online_creation_crop_delta_B,
                         mask_square=self.opt.data_online_creation_mask_square_B,
                         crop_dim=self.opt.data_online_creation_crop_size_B,
                         output_dim=self.opt.data_load_size,
                         context_pixels=self.opt.data_online_context_pixels,
                         load_size=self.opt.data_online_creation_load_size_B,
+                        fixed_mask_size=self.opt.data_online_fixed_mask_size,
                     )
                     B, B_label_mask = self.transform(B_img, B_label_mask)
 

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -649,8 +649,17 @@ class BaseOptions:
             type=int,
             default=[0],
             nargs="*",
-            help="mask offset to allow generation of a bigger object in domain B (for semantic loss) for domain A, format : width (x) height (y) or only one size if square",
+            help="ratio mask offset to allow generation of a bigger object in domain B (for semantic loss) for domain A, format : width (x) height (y) or only one size if square",
         )
+
+        parser.add_argument(
+            "--data_online_creation_mask_random_offset_A",
+            type=float,
+            default=[0.0],
+            nargs="*",
+            help="ratio mask size randomization (only to make bigger one) to robustify the image generation in domain A, format : width (x) height (y) or only one size if square",
+        )
+
         parser.add_argument(
             "--data_online_creation_mask_square_A",
             action="store_true",
@@ -694,6 +703,15 @@ class BaseOptions:
             nargs="*",
             help="mask offset to allow genaration of a bigger object in domain B (for semantic loss) for domain B, format : width (y) height (x) or only one size if square",
         )
+
+        parser.add_argument(
+            "--data_online_creation_mask_random_offset_B",
+            type=float,
+            default=[0.0],
+            nargs="*",
+            help="mask size randomization (only to make bigger one) to robustify the image generation in domain B, format : width (y) height (x) or only one size if square",
+        )
+
         parser.add_argument(
             "--data_online_creation_mask_square_B",
             action="store_true",
@@ -704,6 +722,13 @@ class BaseOptions:
             type=int,
             default=0,
             help="context pixel band around the crop, unused for generation, only for disc ",
+        )
+
+        parser.add_argument(
+            "--data_online_fixed_mask_size",
+            type=int,
+            default=-1,
+            help="if >0, it will be used as fixed bbox size (warning: in dataset resolution ie before resizing) ",
         )
 
         parser.add_argument(


### PR DESCRIPTION
New option to compute a random offset in bbox size at training time. It aims to robustify the model and to make it work with different bboxe sizes at inference time.

Usage:

```
python train.py --data_online_creation_mask_random_offset_A 0.1 --data_online_creation_mask_random_offset_B 0.1 0.0
```