### PR TITLE
feat: unet_attn change groupnorm into batchnorm

### DIFF
--- a/models/diffusion_networks.py
+++ b/models/diffusion_networks.py
@@ -27,6 +27,10 @@ def define_G(
     jg_dir,
     G_padding_type,
     G_config_segformer,
+    G_unet_mha_norm_layer,
+    G_unet_mha_group_norm_size,
+    dropout=0,
+    channel_mults=(1, 2, 4, 8),
     conv_resample=True,
     use_checkpoint=False,
     use_fp16=False,
@@ -74,6 +78,8 @@ def define_G(
             n_timestep_train=G_diff_n_timestep_train,
             n_timestep_test=G_diff_n_timestep_test,
             channel_mults=G_unet_mha_channel_mults,
+            norm=G_unet_mha_norm_layer,
+            group_norm_size=G_unet_mha_group_norm_size,
         )
 
     elif G_netG == "resnet_attn" or G_netG == "mobile_resnet_attn":

--- a/models/gan_networks.py
+++ b/models/gan_networks.py
@@ -66,6 +66,8 @@ def define_G(
     G_backward_compatibility_twice_resnet_blocks,
     G_unet_mha_num_head_channels,
     G_unet_mha_channel_mults,
+    G_unet_mha_norm_layer,
+    G_unet_mha_group_norm_size,
     **unused_options
 ):
     """Create a generator
@@ -225,6 +227,8 @@ def define_G(
             tanh=True,
             n_timestep_train=0,  # unused
             n_timestep_test=0,  # unused
+            norm=G_unet_mha_norm_layer,
+            group_norm_size=G_unet_mha_group_norm_size,
         )
         return net
     else:

--- a/models/modules/unet_generator_attn/switchable_norm.py
+++ b/models/modules/unet_generator_attn/switchable_norm.py
@@ -1,0 +1,245 @@
+import torch
+import torch.nn as nn
+
+
+class SwitchNorm1d(nn.Module):
+    def __init__(
+        self, num_features, eps=1e-5, momentum=0.997, using_moving_average=True
+    ):
+        super(SwitchNorm1d, self).__init__()
+        self.eps = eps
+        self.momentum = momentum
+        self.using_moving_average = using_moving_average
+        self.weight = nn.Parameter(torch.ones(1, num_features))
+        self.bias = nn.Parameter(torch.zeros(1, num_features))
+        self.mean_weight = nn.Parameter(torch.ones(2))
+        self.var_weight = nn.Parameter(torch.ones(2))
+        self.register_buffer("running_mean", torch.zeros(1, num_features))
+        self.register_buffer("running_var", torch.zeros(1, num_features))
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        self.running_mean.zero_()
+        self.running_var.zero_()
+        self.weight.data.fill_(1)
+        self.bias.data.zero_()
+
+    def _check_input_dim(self, input):
+        if input.dim() != 2:
+            raise ValueError("expected 2D input (got {}D input)".format(input.dim()))
+
+    def forward(self, x):
+        self._check_input_dim(x)
+        mean_ln = x.mean(1, keepdim=True)
+        var_ln = x.var(1, keepdim=True)
+
+        if self.training:
+            mean_bn = x.mean(0, keepdim=True)
+            var_bn = x.var(0, keepdim=True)
+            if self.using_moving_average:
+                self.running_mean.mul_(self.momentum)
+                self.running_mean.add_((1 - self.momentum) * mean_bn.data)
+                self.running_var.mul_(self.momentum)
+                self.running_var.add_((1 - self.momentum) * var_bn.data)
+            else:
+                self.running_mean.add_(mean_bn.data)
+                self.running_var.add_(mean_bn.data**2 + var_bn.data)
+        else:
+            mean_bn = torch.autograd.Variable(self.running_mean)
+            var_bn = torch.autograd.Variable(self.running_var)
+
+        softmax = nn.Softmax(0)
+        mean_weight = softmax(self.mean_weight)
+        var_weight = softmax(self.var_weight)
+
+        mean = mean_weight[0] * mean_ln + mean_weight[1] * mean_bn
+        var = var_weight[0] * var_ln + var_weight[1] * var_bn
+
+        x = (x - mean) / (var + self.eps).sqrt()
+        return x * self.weight + self.bias
+
+
+class SwitchNorm2d(nn.Module):
+    def __init__(
+        self,
+        num_features,
+        eps=1e-5,
+        momentum=0.9,
+        using_moving_average=True,
+        using_bn=True,
+        last_gamma=False,
+    ):
+        super(SwitchNorm2d, self).__init__()
+        self.eps = eps
+        self.momentum = momentum
+        self.using_moving_average = using_moving_average
+        self.using_bn = using_bn
+        self.last_gamma = last_gamma
+        self.weight = nn.Parameter(torch.ones(1, num_features, 1, 1))
+        self.bias = nn.Parameter(torch.zeros(1, num_features, 1, 1))
+        if self.using_bn:
+            self.mean_weight = nn.Parameter(torch.ones(3))
+            self.var_weight = nn.Parameter(torch.ones(3))
+        else:
+            self.mean_weight = nn.Parameter(torch.ones(2))
+            self.var_weight = nn.Parameter(torch.ones(2))
+        if self.using_bn:
+            self.register_buffer("running_mean", torch.zeros(1, num_features, 1))
+            self.register_buffer("running_var", torch.zeros(1, num_features, 1))
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.using_bn:
+            self.running_mean.zero_()
+            self.running_var.zero_()
+        if self.last_gamma:
+            self.weight.data.fill_(0)
+        else:
+            self.weight.data.fill_(1)
+        self.bias.data.zero_()
+
+    def _check_input_dim(self, input):
+        if input.dim() != 4:
+            raise ValueError("expected 4D input (got {}D input)".format(input.dim()))
+
+    def forward(self, x):
+        self._check_input_dim(x)
+        N, C, H, W = x.size()
+        x = x.view(N, C, -1)
+        mean_in = x.mean(-1, keepdim=True)
+        var_in = x.var(-1, keepdim=True)
+
+        mean_ln = mean_in.mean(1, keepdim=True)
+        temp = var_in + mean_in**2
+        var_ln = temp.mean(1, keepdim=True) - mean_ln**2
+
+        if self.using_bn:
+            if self.training:
+                mean_bn = mean_in.mean(0, keepdim=True)
+                var_bn = temp.mean(0, keepdim=True) - mean_bn**2
+                if self.using_moving_average:
+                    self.running_mean.mul_(self.momentum)
+                    self.running_mean.add_((1 - self.momentum) * mean_bn.data)
+                    self.running_var.mul_(self.momentum)
+                    self.running_var.add_((1 - self.momentum) * var_bn.data)
+                else:
+                    self.running_mean.add_(mean_bn.data)
+                    self.running_var.add_(mean_bn.data**2 + var_bn.data)
+            else:
+                mean_bn = torch.autograd.Variable(self.running_mean)
+                var_bn = torch.autograd.Variable(self.running_var)
+
+        softmax = nn.Softmax(0)
+        mean_weight = softmax(self.mean_weight)
+        var_weight = softmax(self.var_weight)
+
+        if self.using_bn:
+            mean = (
+                mean_weight[0] * mean_in
+                + mean_weight[1] * mean_ln
+                + mean_weight[2] * mean_bn
+            )
+            var = (
+                var_weight[0] * var_in + var_weight[1] * var_ln + var_weight[2] * var_bn
+            )
+        else:
+            mean = mean_weight[0] * mean_in + mean_weight[1] * mean_ln
+            var = var_weight[0] * var_in + var_weight[1] * var_ln
+
+        x = (x - mean) / (var + self.eps).sqrt()
+        x = x.view(N, C, H, W)
+        return x * self.weight + self.bias
+
+
+class SwitchNorm3d(nn.Module):
+    def __init__(
+        self,
+        num_features,
+        eps=1e-5,
+        momentum=0.997,
+        using_moving_average=True,
+        using_bn=True,
+        last_gamma=False,
+    ):
+        super(SwitchNorm3d, self).__init__()
+        self.eps = eps
+        self.momentum = momentum
+        self.using_moving_average = using_moving_average
+        self.using_bn = using_bn
+        self.last_gamma = last_gamma
+        self.weight = nn.Parameter(torch.ones(1, num_features, 1, 1, 1))
+        self.bias = nn.Parameter(torch.zeros(1, num_features, 1, 1, 1))
+        if self.using_bn:
+            self.mean_weight = nn.Parameter(torch.ones(3))
+            self.var_weight = nn.Parameter(torch.ones(3))
+        else:
+            self.mean_weight = nn.Parameter(torch.ones(2))
+            self.var_weight = nn.Parameter(torch.ones(2))
+        if self.using_bn:
+            self.register_buffer("running_mean", torch.zeros(1, num_features, 1))
+            self.register_buffer("running_var", torch.zeros(1, num_features, 1))
+
+        self.reset_parameters()
+
+    def reset_parameters(self):
+        if self.using_bn:
+            self.running_mean.zero_()
+            self.running_var.zero_()
+        if self.last_gamma:
+            self.weight.data.fill_(0)
+        else:
+            self.weight.data.fill_(1)
+        self.bias.data.zero_()
+
+    def _check_input_dim(self, input):
+        if input.dim() != 5:
+            raise ValueError("expected 5D input (got {}D input)".format(input.dim()))
+
+    def forward(self, x):
+        self._check_input_dim(x)
+        N, C, D, H, W = x.size()
+        x = x.view(N, C, -1)
+        mean_in = x.mean(-1, keepdim=True)
+        var_in = x.var(-1, keepdim=True)
+
+        mean_ln = mean_in.mean(1, keepdim=True)
+        temp = var_in + mean_in**2
+        var_ln = temp.mean(1, keepdim=True) - mean_ln**2
+
+        if self.using_bn:
+            if self.training:
+                mean_bn = mean_in.mean(0, keepdim=True)
+                var_bn = temp.mean(0, keepdim=True) - mean_bn**2
+                if self.using_moving_average:
+                    self.running_mean.mul_(self.momentum)
+                    self.running_mean.add_((1 - self.momentum) * mean_bn.data)
+                    self.running_var.mul_(self.momentum)
+                    self.running_var.add_((1 - self.momentum) * var_bn.data)
+                else:
+                    self.running_mean.add_(mean_bn.data)
+                    self.running_var.add_(mean_bn.data**2 + var_bn.data)
+            else:
+                mean_bn = torch.autograd.Variable(self.running_mean)
+                var_bn = torch.autograd.Variable(self.running_var)
+
+        softmax = nn.Softmax(0)
+        mean_weight = softmax(self.mean_weight)
+        var_weight = softmax(self.var_weight)
+
+        if self.using_bn:
+            mean = (
+                mean_weight[0] * mean_in
+                + mean_weight[1] * mean_ln
+                + mean_weight[2] * mean_bn
+            )
+            var = (
+                var_weight[0] * var_in + var_weight[1] * var_ln + var_weight[2] * var_bn
+            )
+        else:
+            mean = mean_weight[0] * mean_in + mean_weight[1] * mean_ln
+            var = var_weight[0] * var_in + var_weight[1] * var_ln
+
+        x = (x - mean) / (var + self.eps).sqrt()
+        x = x.view(N, C, D, H, W)
+        return x * self.weight + self.bias

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -306,6 +306,25 @@ class BaseOptions:
             help="downrate samples at which attention takes place",
         )
 
+        parser.add_argument(
+            "--G_unet_mha_norm_layer",
+            type=str,
+            choices=[
+                "groupnorm",
+                "batchnorm",
+                "layernorm",
+                "instancenorm",
+                "switchablenorm",
+            ],
+            default="group32norm",
+        )
+
+        parser.add_argument(
+            "--G_unet_mha_group_norm_size",
+            type=int,
+            default=32,
+        )
+
         # discriminator
         parser.add_argument(
             "--D_ndf",

--- a/options/base_options.py
+++ b/options/base_options.py
@@ -316,7 +316,7 @@ class BaseOptions:
                 "instancenorm",
                 "switchablenorm",
             ],
-            default="group32norm",
+            default="groupnorm",
         )
 
         parser.add_argument(

--- a/tests/test_run_diffusion.py
+++ b/tests/test_run_diffusion.py
@@ -33,18 +33,25 @@ json_like_dict = {
 
 models_diffusion = ["palette"]
 G_netG = ["unet_mha"]
-
-product_list = product(models_diffusion, G_netG)
+G_unet_mha_norm_layer = [
+    "groupnorm",
+    "batchnorm",
+    "layernorm",
+    "instancenorm",
+    "switchablenorm",
+]
+product_list = product(models_diffusion, G_netG, G_unet_mha_norm_layer)
 
 
 def test_diffusion(dataroot):
     json_like_dict["dataroot"] = dataroot
     json_like_dict["checkpoints_dir"] = "/".join(dataroot.split("/")[:-1])
-    for model, Gtype in product_list:
+    for model, Gtype, G_norm in product_list:
         json_like_dict_c = json_like_dict.copy()
         json_like_dict_c["model_type"] = model
         json_like_dict_c["name"] += "_" + model
         json_like_dict_c["G_netG"] = Gtype
+        json_like_dict_c["G_unet_mha_norm_layer"] = G_norm
 
         opt = TrainOptions().parse_json(json_like_dict_c)
         train.launch_training(opt)


### PR DESCRIPTION
Replace groupnorm layers by batchnorm (and instance norm when 1D) in unet attn generator.

Note: for multigpu we need to convert batch norm into syncbatchnorm (automatically done in joligan) but for inference we need to convert it into batchnorm again (because inference is only done on first gpu).

New option : 
`--G_unet_mha_norm_layer` : choices : `["batchnorm","group32norm","switchablenorm"]` 