### PR TITLE
feat: random edge detection method at training [2302.05543]

### DIFF
--- a/models/modules/sketch_generation/hed.py
+++ b/models/modules/sketch_generation/hed.py
@@ -1,0 +1,192 @@
+import os
+
+import numpy as np
+import torch
+from einops import rearrange
+
+from util.util import load_file_from_url
+
+
+class Network(torch.nn.Module):
+    def __init__(self, model_path):
+        super().__init__()
+
+        self.netVggOne = torch.nn.Sequential(
+            torch.nn.Conv2d(
+                in_channels=3, out_channels=64, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+            torch.nn.Conv2d(
+                in_channels=64, out_channels=64, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+        )
+
+        self.netVggTwo = torch.nn.Sequential(
+            torch.nn.MaxPool2d(kernel_size=2, stride=2),
+            torch.nn.Conv2d(
+                in_channels=64, out_channels=128, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+            torch.nn.Conv2d(
+                in_channels=128, out_channels=128, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+        )
+
+        self.netVggThr = torch.nn.Sequential(
+            torch.nn.MaxPool2d(kernel_size=2, stride=2),
+            torch.nn.Conv2d(
+                in_channels=128, out_channels=256, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+            torch.nn.Conv2d(
+                in_channels=256, out_channels=256, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+            torch.nn.Conv2d(
+                in_channels=256, out_channels=256, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+        )
+
+        self.netVggFou = torch.nn.Sequential(
+            torch.nn.MaxPool2d(kernel_size=2, stride=2),
+            torch.nn.Conv2d(
+                in_channels=256, out_channels=512, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+            torch.nn.Conv2d(
+                in_channels=512, out_channels=512, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+            torch.nn.Conv2d(
+                in_channels=512, out_channels=512, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+        )
+
+        self.netVggFiv = torch.nn.Sequential(
+            torch.nn.MaxPool2d(kernel_size=2, stride=2),
+            torch.nn.Conv2d(
+                in_channels=512, out_channels=512, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+            torch.nn.Conv2d(
+                in_channels=512, out_channels=512, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+            torch.nn.Conv2d(
+                in_channels=512, out_channels=512, kernel_size=3, stride=1, padding=1
+            ),
+            torch.nn.ReLU(inplace=False),
+        )
+
+        self.netScoreOne = torch.nn.Conv2d(
+            in_channels=64, out_channels=1, kernel_size=1, stride=1, padding=0
+        )
+        self.netScoreTwo = torch.nn.Conv2d(
+            in_channels=128, out_channels=1, kernel_size=1, stride=1, padding=0
+        )
+        self.netScoreThr = torch.nn.Conv2d(
+            in_channels=256, out_channels=1, kernel_size=1, stride=1, padding=0
+        )
+        self.netScoreFou = torch.nn.Conv2d(
+            in_channels=512, out_channels=1, kernel_size=1, stride=1, padding=0
+        )
+        self.netScoreFiv = torch.nn.Conv2d(
+            in_channels=512, out_channels=1, kernel_size=1, stride=1, padding=0
+        )
+
+        self.netCombine = torch.nn.Sequential(
+            torch.nn.Conv2d(
+                in_channels=5, out_channels=1, kernel_size=1, stride=1, padding=0
+            ),
+            torch.nn.Sigmoid(),
+        )
+
+        self.load_state_dict(
+            {
+                strKey.replace("module", "net"): tenWeight
+                for strKey, tenWeight in torch.load(model_path).items()
+            }
+        )
+
+    def forward(self, tenInput):
+        tenInput = tenInput * 255.0
+        tenInput = tenInput - torch.tensor(
+            data=[104.00698793, 116.66876762, 122.67891434],
+            dtype=tenInput.dtype,
+            device=tenInput.device,
+        ).view(1, 3, 1, 1)
+
+        tenVggOne = self.netVggOne(tenInput)
+        tenVggTwo = self.netVggTwo(tenVggOne)
+        tenVggThr = self.netVggThr(tenVggTwo)
+        tenVggFou = self.netVggFou(tenVggThr)
+        tenVggFiv = self.netVggFiv(tenVggFou)
+
+        tenScoreOne = self.netScoreOne(tenVggOne)
+        tenScoreTwo = self.netScoreTwo(tenVggTwo)
+        tenScoreThr = self.netScoreThr(tenVggThr)
+        tenScoreFou = self.netScoreFou(tenVggFou)
+        tenScoreFiv = self.netScoreFiv(tenVggFiv)
+
+        tenScoreOne = torch.nn.functional.interpolate(
+            input=tenScoreOne,
+            size=(tenInput.shape[2], tenInput.shape[3]),
+            mode="bilinear",
+            align_corners=False,
+        )
+        tenScoreTwo = torch.nn.functional.interpolate(
+            input=tenScoreTwo,
+            size=(tenInput.shape[2], tenInput.shape[3]),
+            mode="bilinear",
+            align_corners=False,
+        )
+        tenScoreThr = torch.nn.functional.interpolate(
+            input=tenScoreThr,
+            size=(tenInput.shape[2], tenInput.shape[3]),
+            mode="bilinear",
+            align_corners=False,
+        )
+        tenScoreFou = torch.nn.functional.interpolate(
+            input=tenScoreFou,
+            size=(tenInput.shape[2], tenInput.shape[3]),
+            mode="bilinear",
+            align_corners=False,
+        )
+        tenScoreFiv = torch.nn.functional.interpolate(
+            input=tenScoreFiv,
+            size=(tenInput.shape[2], tenInput.shape[3]),
+            mode="bilinear",
+            align_corners=False,
+        )
+
+        return self.netCombine(
+            torch.cat(
+                [tenScoreOne, tenScoreTwo, tenScoreThr, tenScoreFou, tenScoreFiv], 1
+            )
+        )
+
+
+class HEDdetector:
+    def __init__(self):
+        dir = os.path.dirname(__file__)
+        model_dir = os.path.join(dir, "../../configs/pretrained/")
+        remote_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/network-bsds500.pth"
+        modelpath = os.path.join(model_dir, "network-bsds500.pth")
+        if not os.path.exists(modelpath):
+            load_file_from_url(remote_model_path, model_dir)
+        self.netNetwork = Network(modelpath).cuda().eval()
+
+    def __call__(self, input_image):
+        assert input_image.ndim == 3
+        input_image = input_image[:, :, ::-1].copy()
+        with torch.no_grad():
+            image_hed = torch.from_numpy(input_image).float().cuda()
+            image_hed = image_hed / 255.0
+            image_hed = rearrange(image_hed, "h w c -> 1 c h w")
+            edge = self.netNetwork(image_hed)[0]
+            edge = (edge.cpu().numpy() * 255.0).clip(0, 255).astype(np.uint8)
+            return edge[0]

--- a/models/modules/sketch_generation/mbv2_mlsd_large.py
+++ b/models/modules/sketch_generation/mbv2_mlsd_large.py
@@ -1,0 +1,311 @@
+import os
+import sys
+
+import torch
+import torch.nn as nn
+import torch.utils.model_zoo as model_zoo
+from torch.nn import functional as F
+
+
+class BlockTypeA(nn.Module):
+    def __init__(self, in_c1, in_c2, out_c1, out_c2, upscale=True):
+        super(BlockTypeA, self).__init__()
+        self.conv1 = nn.Sequential(
+            nn.Conv2d(in_c2, out_c2, kernel_size=1),
+            nn.BatchNorm2d(out_c2),
+            nn.ReLU(inplace=True),
+        )
+        self.conv2 = nn.Sequential(
+            nn.Conv2d(in_c1, out_c1, kernel_size=1),
+            nn.BatchNorm2d(out_c1),
+            nn.ReLU(inplace=True),
+        )
+        self.upscale = upscale
+
+    def forward(self, a, b):
+        b = self.conv1(b)
+        a = self.conv2(a)
+        if self.upscale:
+            b = F.interpolate(b, scale_factor=2.0, mode="bilinear", align_corners=True)
+        return torch.cat((a, b), dim=1)
+
+
+class BlockTypeB(nn.Module):
+    def __init__(self, in_c, out_c):
+        super(BlockTypeB, self).__init__()
+        self.conv1 = nn.Sequential(
+            nn.Conv2d(in_c, in_c, kernel_size=3, padding=1),
+            nn.BatchNorm2d(in_c),
+            nn.ReLU(),
+        )
+        self.conv2 = nn.Sequential(
+            nn.Conv2d(in_c, out_c, kernel_size=3, padding=1),
+            nn.BatchNorm2d(out_c),
+            nn.ReLU(),
+        )
+
+    def forward(self, x):
+        x = self.conv1(x) + x
+        x = self.conv2(x)
+        return x
+
+
+class BlockTypeC(nn.Module):
+    def __init__(self, in_c, out_c):
+        super(BlockTypeC, self).__init__()
+        self.conv1 = nn.Sequential(
+            nn.Conv2d(in_c, in_c, kernel_size=3, padding=5, dilation=5),
+            nn.BatchNorm2d(in_c),
+            nn.ReLU(),
+        )
+        self.conv2 = nn.Sequential(
+            nn.Conv2d(in_c, in_c, kernel_size=3, padding=1),
+            nn.BatchNorm2d(in_c),
+            nn.ReLU(),
+        )
+        self.conv3 = nn.Conv2d(in_c, out_c, kernel_size=1)
+
+    def forward(self, x):
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        return x
+
+
+def _make_divisible(v, divisor, min_value=None):
+    """
+    This function is taken from the original tf repo.
+    It ensures that all layers have a channel number that is divisible by 8
+    It can be seen here:
+    https://github.com/tensorflow/models/blob/master/research/slim/nets/mobilenet/mobilenet.py
+    :param v:
+    :param divisor:
+    :param min_value:
+    :return:
+    """
+    if min_value is None:
+        min_value = divisor
+    new_v = max(min_value, int(v + divisor / 2) // divisor * divisor)
+    # Make sure that round down does not go down by more than 10%.
+    if new_v < 0.9 * v:
+        new_v += divisor
+    return new_v
+
+
+class ConvBNReLU(nn.Sequential):
+    def __init__(self, in_planes, out_planes, kernel_size=3, stride=1, groups=1):
+        self.channel_pad = out_planes - in_planes
+        self.stride = stride
+        # padding = (kernel_size - 1) // 2
+
+        # TFLite uses slightly different padding than PyTorch
+        if stride == 2:
+            padding = 0
+        else:
+            padding = (kernel_size - 1) // 2
+
+        super(ConvBNReLU, self).__init__(
+            nn.Conv2d(
+                in_planes,
+                out_planes,
+                kernel_size,
+                stride,
+                padding,
+                groups=groups,
+                bias=False,
+            ),
+            nn.BatchNorm2d(out_planes),
+            nn.ReLU6(inplace=True),
+        )
+        self.max_pool = nn.MaxPool2d(kernel_size=stride, stride=stride)
+
+    def forward(self, x):
+        # TFLite uses  different padding
+        if self.stride == 2:
+            x = F.pad(x, (0, 1, 0, 1), "constant", 0)
+            # print(x.shape)
+
+        for module in self:
+            if not isinstance(module, nn.MaxPool2d):
+                x = module(x)
+        return x
+
+
+class InvertedResidual(nn.Module):
+    def __init__(self, inp, oup, stride, expand_ratio):
+        super(InvertedResidual, self).__init__()
+        self.stride = stride
+        assert stride in [1, 2]
+
+        hidden_dim = int(round(inp * expand_ratio))
+        self.use_res_connect = self.stride == 1 and inp == oup
+
+        layers = []
+        if expand_ratio != 1:
+            # pw
+            layers.append(ConvBNReLU(inp, hidden_dim, kernel_size=1))
+        layers.extend(
+            [
+                # dw
+                ConvBNReLU(hidden_dim, hidden_dim, stride=stride, groups=hidden_dim),
+                # pw-linear
+                nn.Conv2d(hidden_dim, oup, 1, 1, 0, bias=False),
+                nn.BatchNorm2d(oup),
+            ]
+        )
+        self.conv = nn.Sequential(*layers)
+
+    def forward(self, x):
+        if self.use_res_connect:
+            return x + self.conv(x)
+        else:
+            return self.conv(x)
+
+
+class MobileNetV2(nn.Module):
+    def __init__(self, pretrained=True):
+        """
+        MobileNet V2 main class
+        Args:
+            num_classes (int): Number of classes
+            width_mult (float): Width multiplier - adjusts number of channels in each layer by this amount
+            inverted_residual_setting: Network structure
+            round_nearest (int): Round the number of channels in each layer to be a multiple of this number
+            Set to 1 to turn off rounding
+            block: Module specifying inverted residual building block for mobilenet
+        """
+        super(MobileNetV2, self).__init__()
+
+        block = InvertedResidual
+        input_channel = 32
+        last_channel = 1280
+        width_mult = 1.0
+        round_nearest = 8
+
+        inverted_residual_setting = [
+            # t, c, n, s
+            [1, 16, 1, 1],
+            [6, 24, 2, 2],
+            [6, 32, 3, 2],
+            [6, 64, 4, 2],
+            [6, 96, 3, 1],
+            # [6, 160, 3, 2],
+            # [6, 320, 1, 1],
+        ]
+
+        # only check the first element, assuming user knows t,c,n,s are required
+        if (
+            len(inverted_residual_setting) == 0
+            or len(inverted_residual_setting[0]) != 4
+        ):
+            raise ValueError(
+                "inverted_residual_setting should be non-empty "
+                "or a 4-element list, got {}".format(inverted_residual_setting)
+            )
+
+        # building first layer
+        input_channel = _make_divisible(input_channel * width_mult, round_nearest)
+        self.last_channel = _make_divisible(
+            last_channel * max(1.0, width_mult), round_nearest
+        )
+        features = [ConvBNReLU(4, input_channel, stride=2)]
+        # building inverted residual blocks
+        for t, c, n, s in inverted_residual_setting:
+            output_channel = _make_divisible(c * width_mult, round_nearest)
+            for i in range(n):
+                stride = s if i == 0 else 1
+                features.append(
+                    block(input_channel, output_channel, stride, expand_ratio=t)
+                )
+                input_channel = output_channel
+
+        self.features = nn.Sequential(*features)
+        self.fpn_selected = [1, 3, 6, 10, 13]
+        # weight initialization
+        for m in self.modules():
+            if isinstance(m, nn.Conv2d):
+                nn.init.kaiming_normal_(m.weight, mode="fan_out")
+                if m.bias is not None:
+                    nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.BatchNorm2d):
+                nn.init.ones_(m.weight)
+                nn.init.zeros_(m.bias)
+            elif isinstance(m, nn.Linear):
+                nn.init.normal_(m.weight, 0, 0.01)
+                nn.init.zeros_(m.bias)
+        if pretrained:
+            self._load_pretrained_model()
+
+    def _forward_impl(self, x):
+        # This exists since TorchScript doesn't support inheritance, so the superclass method
+        # (this one) needs to have a name other than `forward` that can be accessed in a subclass
+        fpn_features = []
+        for i, f in enumerate(self.features):
+            if i > self.fpn_selected[-1]:
+                break
+            x = f(x)
+            if i in self.fpn_selected:
+                fpn_features.append(x)
+
+        c1, c2, c3, c4, c5 = fpn_features
+        return c1, c2, c3, c4, c5
+
+    def forward(self, x):
+        return self._forward_impl(x)
+
+    def _load_pretrained_model(self):
+        pretrain_dict = model_zoo.load_url(
+            "https://download.pytorch.org/models/mobilenet_v2-b0353104.pth"
+        )
+        model_dict = {}
+        state_dict = self.state_dict()
+        for k, v in pretrain_dict.items():
+            if k in state_dict:
+                model_dict[k] = v
+        state_dict.update(model_dict)
+        self.load_state_dict(state_dict)
+
+
+class MobileV2_MLSD_Large(nn.Module):
+    def __init__(self):
+        super(MobileV2_MLSD_Large, self).__init__()
+
+        self.backbone = MobileNetV2(pretrained=False)
+        ## A, B
+        self.block15 = BlockTypeA(
+            in_c1=64, in_c2=96, out_c1=64, out_c2=64, upscale=False
+        )
+        self.block16 = BlockTypeB(128, 64)
+
+        ## A, B
+        self.block17 = BlockTypeA(in_c1=32, in_c2=64, out_c1=64, out_c2=64)
+        self.block18 = BlockTypeB(128, 64)
+
+        ## A, B
+        self.block19 = BlockTypeA(in_c1=24, in_c2=64, out_c1=64, out_c2=64)
+        self.block20 = BlockTypeB(128, 64)
+
+        ## A, B, C
+        self.block21 = BlockTypeA(in_c1=16, in_c2=64, out_c1=64, out_c2=64)
+        self.block22 = BlockTypeB(128, 64)
+
+        self.block23 = BlockTypeC(64, 16)
+
+    def forward(self, x):
+        c1, c2, c3, c4, c5 = self.backbone(x)
+
+        x = self.block15(c4, c5)
+        x = self.block16(x)
+
+        x = self.block17(c3, x)
+        x = self.block18(x)
+
+        x = self.block19(c2, x)
+        x = self.block20(x)
+
+        x = self.block21(c1, x)
+        x = self.block22(x)
+        x = self.block23(x)
+        x = x[:, 7:, :, :]
+
+        return x

--- a/models/modules/sketch_generation/mlsd.py
+++ b/models/modules/sketch_generation/mlsd.py
@@ -1,0 +1,125 @@
+import os
+
+import cv2
+import numpy as np
+import torch
+from torch.nn import functional as F
+
+from models.modules.sketch_generation.mbv2_mlsd_large import MobileV2_MLSD_Large
+from util.util import load_file_from_url
+
+
+def deccode_output_score_and_ptss(tpMap, topk_n=200, ksize=5):
+    """
+    tpMap:
+    center: tpMap[1, 0, :, :]
+    displacement: tpMap[1, 1:5, :, :]
+    """
+    b, c, h, w = tpMap.shape
+    assert b == 1, "only support bsize==1"
+    displacement = tpMap[:, 1:5, :, :][0]
+    center = tpMap[:, 0, :, :]
+    heat = torch.sigmoid(center)
+    hmax = F.max_pool2d(heat, (ksize, ksize), stride=1, padding=(ksize - 1) // 2)
+    keep = (hmax == heat).float()
+    heat = heat * keep
+    heat = heat.reshape(
+        -1,
+    )
+
+    scores, indices = torch.topk(heat, topk_n, dim=-1, largest=True)
+    yy = torch.floor_divide(indices, w).unsqueeze(-1)
+    xx = torch.fmod(indices, w).unsqueeze(-1)
+    ptss = torch.cat((yy, xx), dim=-1)
+
+    ptss = ptss.detach().cpu().numpy()
+    scores = scores.detach().cpu().numpy()
+    displacement = displacement.detach().cpu().numpy()
+    displacement = displacement.transpose((1, 2, 0))
+    return ptss, scores, displacement
+
+
+def pred_lines(image, model, input_shape=[256, 256], score_thr=0.10, dist_thr=20.0):
+    h, w, _ = image.shape
+    h_ratio, w_ratio = [h / input_shape[0], w / input_shape[1]]
+    resized_image = np.concatenate(
+        [
+            cv2.resize(
+                image, (input_shape[1], input_shape[0]), interpolation=cv2.INTER_AREA
+            ),
+            np.ones([input_shape[0], input_shape[1], 1]),
+        ],
+        axis=-1,
+    )
+
+    resized_image = resized_image.transpose((2, 0, 1))
+    batch_image = np.expand_dims(resized_image, axis=0).astype("float32")
+    batch_image = (batch_image / 127.5) - 1.0
+
+    batch_image = torch.from_numpy(batch_image).float().cuda()
+    outputs = model(batch_image)
+    pts, pts_score, vmap = deccode_output_score_and_ptss(outputs, 200, 3)
+    start = vmap[:, :, :2]
+    end = vmap[:, :, 2:]
+    dist_map = np.sqrt(np.sum((start - end) ** 2, axis=-1))
+
+    segments_list = []
+    for center, score in zip(pts, pts_score):
+        y, x = center
+        distance = dist_map[y, x]
+        if score > score_thr and distance > dist_thr:
+            disp_x_start, disp_y_start, disp_x_end, disp_y_end = vmap[y, x, :]
+            x_start = x + disp_x_start
+            y_start = y + disp_y_start
+            x_end = x + disp_x_end
+            y_end = y + disp_y_end
+            segments_list.append([x_start, y_start, x_end, y_end])
+
+    lines = 2 * np.array(segments_list)  # 256 > 512
+    lines[:, 0] = lines[:, 0] * w_ratio
+    lines[:, 1] = lines[:, 1] * h_ratio
+    lines[:, 2] = lines[:, 2] * w_ratio
+    lines[:, 3] = lines[:, 3] * h_ratio
+
+    return lines
+
+
+class MLSDdetector:
+    def __init__(self):
+        dir = os.path.dirname(__file__)
+        model_dir = os.path.join(dir, "../../configs/pretrained/")
+        remote_model_path = "https://huggingface.co/lllyasviel/ControlNet/resolve/main/annotator/ckpts/mlsd_large_512_fp32.pth"
+        model_path = os.path.join(model_dir, "mlsd_large_512_fp32.pth")
+        if not os.path.exists(model_path):
+            load_file_from_url(remote_model_path, model_dir)
+
+        model = MobileV2_MLSD_Large()
+        model.load_state_dict(torch.load(model_path), strict=True)
+        self.model = model.cuda().eval()
+
+    def __call__(self, input_image, thr_v, thr_d):
+        assert input_image.ndim == 3
+        img = input_image
+        img_output = np.zeros_like(img)
+        img_um = cv2.UMat(img_output)
+        try:
+            with torch.no_grad():
+                lines = pred_lines(
+                    img, self.model, [img.shape[0], img.shape[1]], thr_v, thr_d
+                )
+                for line in lines:
+                    x_start, y_start, x_end, y_end = [int(val) for val in line]
+                    cv2.line(
+                        img_um,
+                        (x_start, y_start),
+                        (x_end, y_end),
+                        [255, 255, 255],
+                        1,
+                    )
+
+        except Exception as e:
+            print(e)
+            pass
+
+        img_with_line = img_um.get()
+        return img_with_line[:, :, 0]

--- a/util/mask_generation.py
+++ b/util/mask_generation.py
@@ -1,10 +1,25 @@
-import torch
-from torchvision.transforms import Grayscale
+import os
+import random
+import sys
+import urllib.request
+
 import cv2
 import numpy as np
+import requests
+import torch
+from torch.nn import functional as F
+from torchvision.transforms import Grayscale
+
+from models.modules.sketch_generation.hed import HEDdetector
+from models.modules.sketch_generation.mlsd import MLSDdetector
+from models.modules.utils import download_midas_weight, predict_depth
+
+sys.path.append("./../")
 
 
 def fill_img_with_sketch(img, mask):
+    """Fill the masked region with sketch edges."""
+
     grayscale = Grayscale(3)
     gray = grayscale(img)
 
@@ -17,27 +32,139 @@ def fill_img_with_sketch(img, mask):
     return mask * thresh + (1 - mask) * img
 
 
-def fill_img_with_edges(img, mask):
+def fill_img_with_canny(img, mask, low_threshold=None, high_threshold=None):
+    """Fill the masked region with canny edges."""
+    max_value = 255 * 3
+    if high_threshold is None and low_threshold is None:
+        threshold_1 = random.randint(0, max_value)
+        threshold_2 = random.randint(0, max_value)
+        high_threshold = max(threshold_1, threshold_2)
+        low_threshold = min(threshold_1, threshold_2)
+    elif high_threshold is None and low_threshold is not None:
+        high_threshold = random.randint(low_threshold, max_value)
+    elif high_threshold is not None and low_threshold is None:
+        low_threshold = random.randint(0, high_threshold)
 
     device = img.device
-
     edges_list = []
-
     for cur_img in img:
         cur_img = (
             (torch.einsum("chw->hwc", cur_img).cpu().numpy() + 1) * 255 / 2
         ).astype(np.uint8)
-        edges = cv2.Canny(cur_img, 100, 150)
+        edges = cv2.Canny(cur_img, low_threshold, high_threshold)
         edges = (
             (((torch.tensor(edges, device=device) / 255) * 2) - 1)
             .unsqueeze(0)
             .unsqueeze(0)
         )
-
         edges_list.append(edges)
-
     edges = torch.cat(edges_list, dim=0)
-
     mask = torch.clamp(mask, 0, 1)
 
     return mask * edges + (1 - mask) * img
+
+
+def fill_img_with_hed(img, mask):
+    """Fill the masked region with HED edges from the ControlNet paper."""
+
+    apply_hed = HEDdetector()
+    device = img.device
+    edges_list = []
+    for cur_img in img:
+        cur_img = (
+            (torch.einsum("chw->hwc", cur_img).cpu().numpy() + 1) * 255 / 2
+        ).astype(np.uint8)
+        detected_map = apply_hed(cur_img)
+        detected_map = (
+            (((torch.tensor(detected_map, device=device) / 255) * 2) - 1)
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+        edges_list.append(detected_map)
+    edges = torch.cat(edges_list, dim=0)
+    mask = torch.clamp(mask, 0, 1)
+
+    return mask * edges + (1 - mask) * img
+
+
+def fill_img_with_hough(
+    img, mask, value_threshold=1e-05, distance_threshold=10.0, with_canny=False
+):
+    """Fill the masked region with Hough lines detection from the ControlNet paper."""
+
+    if with_canny:
+        img = fill_img_with_canny(img, mask)
+
+    device = img.device
+    apply_mlsd = MLSDdetector()
+    edges_list = []
+    for cur_img in img:
+        cur_img = (
+            (torch.einsum("chw->hwc", cur_img).cpu().numpy() + 1) * 255 / 2
+        ).astype(np.uint8)
+        detected_map = apply_mlsd(
+            cur_img, thr_v=value_threshold, thr_d=distance_threshold
+        )
+        detected_map = (
+            (((torch.tensor(detected_map, device=device) / 255) * 2) - 1)
+            .unsqueeze(0)
+            .unsqueeze(0)
+        )
+        edges_list.append(detected_map)
+    edges = torch.cat(edges_list, dim=0)
+    mask = torch.clamp(mask, 0, 1)
+
+    return mask * edges + (1 - mask) * img
+
+
+def fill_img_with_depth(img, mask, depth_network="DPT_SwinV2_T_256"):
+    """Fill the masked region with depth map."""
+
+    device = img.device
+    midas_w = download_midas_weight(model_type=depth_network)
+    edges_list = []
+    for cur_img in img:
+        cur_img = torch.from_numpy(
+            np.transpose(
+                ((torch.einsum("chw->hwc", cur_img).cpu() + 1) * 255 / 2).numpy(),
+                (2, 0, 1),
+            )
+        ).float()
+        depth_map = predict_depth(
+            img=cur_img.unsqueeze(0), midas=midas_w, model_type=depth_network
+        )
+        if (depth_map.shape[0], depth_map.shape[1]) != (
+            cur_img.shape[1],
+            cur_img.shape[2],
+        ):
+            depth_map = torch.nn.functional.interpolate(
+                depth_map.unsqueeze(1),
+                size=cur_img.shape[1:],
+                mode="bilinear",
+            ).squeeze()
+        depth_map = (
+            ((torch.tensor(depth_map, device=device) / 255) * 2) - 1
+        ).unsqueeze(0)
+        edges_list.append(depth_map)
+    edges = torch.cat(edges_list, dim=0)
+    mask = torch.clamp(mask, 0, 1)
+
+    return mask * edges + (1 - mask) * img
+
+
+def random_edge_mask(fn_list):
+    edge_fns = []
+    for fn in fn_list:
+        if fn == "canny":
+            edge_fns.append(fill_img_with_canny)
+        elif fn == "hed":
+            edge_fns.append(fill_img_with_hed)
+        elif fn == "hough":
+            edge_fns.append(fill_img_with_hough)
+        elif fn == "depth":
+            edge_fns.append(fill_img_with_depth)
+        elif fn == "sketch":
+            edge_fns.append(fill_img_with_sketch)
+        else:
+            raise NotImplementedError(f"Unknown edge function {fn}")
+    return random.choice(edge_fns)

--- a/util/util.py
+++ b/util/util.py
@@ -1,13 +1,15 @@
 """This module contains simple helper functions """
 from __future__ import print_function
-import torch
-import numpy as np
-from PIL import Image
+
 import os
+
+import numpy as np
+import requests
+import torch
+from PIL import Image
 
 
 def display_mask(mask):
-
     dict_col = np.array(
         [
             [0, 0, 0],  # black
@@ -74,6 +76,20 @@ def tensor2im(input_image, imtype=np.uint8):
     else:  # if it is a numpy array, do nothing
         image_numpy = input_image
     return image_numpy.astype(imtype)
+
+
+def load_file_from_url(url, directory):
+    # Create the directory if it doesn't exist
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    # Extract the filename from the URL
+    filename = url.split("/")[-1]
+
+    # Download the file
+    response = requests.get(url)
+    with open(os.path.join(directory, filename), "wb") as f:
+        f.write(response.content)
 
 
 def diagnose_network(net, name="network"):


### PR DESCRIPTION
# Contents
Added possibility for random edge detection method at training (Canny, HED, Hough, Depth)

# Usage

Change `alg.palette_cond_image_creation` in your `train_config.json` model file to "random_sketch" for the model to choose a random edge detection function from #377 

## Example
```
python3 train.py --dataroot path/to/data/ --checkpoints_dir path/to/checkpoints/ --name noglasses2glasses \
--data_direction BtoA --output_display_env noglasses2glasses --gpu_ids 0,1 --model_type palette \ 
--train_batch_size 4 --train_iter_size 16 --model_input_nc 3 --model_output_nc 3 --data_relative_paths \ 
--train_G_ema --train_optim radam --data_dataset_mode self_supervised_labeled_mask \ 
--data_load_size 256 --data_crop_size 256 --G_netG unet_mha --data_online_creation_rand_mask_A \ 
--train_G_lr 0.00002 --train_n_epochs 200 --dataaug_no_rotate --output_display_freq 100 \
--train_optim adamw --G_nblocks 2 --alg_palette_cond_image_creation random_sketch
```