### PR TITLE
chore: compatibility with pytorch2

### DIFF
--- a/options/base_options.py
+++ b/options/base_options.py
@@ -103,6 +103,11 @@ class BaseOptions:
             help="whether to activate tf32 for faster computations (Ampere GPU and beyond only)",
         )
         parser.add_argument(
+            "--with_torch_compile",
+            action="store_true",
+            help="whether to activate torch.compile for some forward and backward functions (experimental)",
+        )
+        parser.add_argument(
             "--checkpoints_dir",
             type=str,
             default="./checkpoints",

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ addict
 thop
 pydantic
 positional_encodings
+onnx


### PR DESCRIPTION
New features:
- torch.compile with `--with_torch_compile`, works for palette diffusion models

Broken features:
- segformer ONNX export
- torch.compile fails on GANs, not on all models of generators and discriminators, but most often. Since torch.compile is still relatively experimental it is left available for GANs, but is crashing at the moment for those models.