### PR TITLE
chore: docker build image requirements requires upgrade for numpy

### DIFF
--- a/docker/Dockerfile.build
+++ b/docker/Dockerfile.build
@@ -15,7 +15,7 @@ RUN mkdir /app
 
 WORKDIR /app
 ADD requirements.txt .
-RUN pip3 install -r requirements.txt
+RUN pip3 install -r requirements.txt --upgrade
 RUN pip3 install uvicorn[standard] fastapi
 RUN mkdir .cache && mkdir .cache/torch 
 RUN export TORCH_HOME=/app/.cache/torch


### PR DESCRIPTION
Fixes the `ValueError: numpy.ndarray size changed, may indicate binary incompatibility. Expected 88 from C header, got 80 from PyObject` error at docker server startup.