### PR TITLE
fix: online mask padding

### DIFF
--- a/data/online_creation.py
+++ b/data/online_creation.py
@@ -241,6 +241,13 @@ def crop_image(
                 constant_values=0,
             )
 
+            mask = np.pad(
+                mask,
+                ((y_padding, x_padding), (y_padding, x_padding)),
+                "constant",
+                constant_values=0,
+            )
+
             x_max_ref += x_padding
             x_min_ref += x_padding
             y_max_ref += y_padding


### PR DESCRIPTION
Online mask padding was missing when the image is for instance smaller than the requested crop size, and needs to be padded.